### PR TITLE
Fix: API endpoint for getting integration brains

### DIFF
--- a/frontend/lib/api/brain/brain.ts
+++ b/frontend/lib/api/brain/brain.ts
@@ -160,6 +160,6 @@ export const getDocsFromQuestion = async (
 export const getIntegrationBrains = async (
   axiosInstance: AxiosInstance
 ): Promise<IntegrationBrains[]> => {
-  return (await axiosInstance.get<IntegrationBrains[]>(`/brains/integrations`))
+  return (await axiosInstance.get<IntegrationBrains[]>(`/brains/integrations/`))
     .data;
 };


### PR DESCRIPTION
This pull request fixes the API endpoint for getting integration brains. Previously, the endpoint was missing a trailing slash, causing the request to fail. This PR adds the missing slash to the endpoint, ensuring that the request is successful.