### PR TITLE
fix: get_brain_details API to include user_id parameter

### DIFF
--- a/backend/repository/brain_subscription/resend_invitation_email.py
+++ b/backend/repository/brain_subscription/resend_invitation_email.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from logger import get_logger
 from models import BrainSettings, BrainSubscription
 from modules.brain.service.brain_service import BrainService
@@ -12,13 +14,16 @@ brain_service = BrainService()
 def resend_invitation_email(
     brain_subscription: BrainSubscription,
     inviter_email: str,
+    user_id: UUID,
     origin: str = "https://www.quivr.app",
 ):
     brains_settings = BrainSettings()  # pyright: ignore reportPrivateUsage=none
 
     brain_url = get_brain_url(origin, brain_subscription.brain_id)
 
-    invitation_brain = brain_service.get_brain_details(brain_subscription.brain_id)
+    invitation_brain = brain_service.get_brain_details(
+        brain_subscription.brain_id, user_id
+    )
     if invitation_brain is None:
         raise Exception("Brain not found")
     brain_name = invitation_brain.name

--- a/backend/routes/subscription_routes.py
+++ b/backend/routes/subscription_routes.py
@@ -82,6 +82,7 @@ def invite_users_to_brain(
                 resend_invitation_email(
                     subscription,
                     inviter_email=current_user.email or "Quivr",
+                    user_id=current_user.id,
                     origin=origin,
                 )
         except Exception as e:


### PR DESCRIPTION
This pull request fixes the `get_brain_details` API by adding a `user_id` parameter. Previously, the API did not include the `user_id` parameter, which caused issues when retrieving brain details. This fix ensures that the `user_id` is passed correctly to the API, allowing for accurate retrieval of brain details.