### PR TITLE
Reduce sampling rate for Sentry traces

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -44,6 +44,7 @@ if sentry_dsn:
         dsn=sentry_dsn,
         sample_rate=0.1,
         enable_tracing=True,
+        traces_sample_rate=0.1,
         integrations=[
             StarletteIntegration(transaction_style="endpoint"),
             FastApiIntegration(transaction_style="endpoint"),

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -14,6 +14,7 @@ if (SENTRY_DSN) {
 
     // Adjust this value in production, or use tracesSampler for greater control
     sampleRate: 0.1,
+    tracesSampleRate: 0.1,
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,


### PR DESCRIPTION
This pull request reduces the sampling rate for Sentry traces to 0.1. This change ensures that only a small percentage of traces are captured, which helps to reduce the impact on performance and storage.