### PR TITLE
Add max_input and max_tokens parameters to KnowledgeBrainQA constructor

### DIFF
--- a/backend/modules/brain/knowledge_brain_qa.py
+++ b/backend/modules/brain/knowledge_brain_qa.py
@@ -181,6 +181,8 @@ class KnowledgeBrainQA(BaseModel, QAInterface):
             brain_id=brain_id,
             chat_id=chat_id,
             streaming=streaming,
+            max_input=self.max_input,
+            max_tokens=self.max_tokens,
             **kwargs,
         )
 


### PR DESCRIPTION
This pull request adds the `max_input` and `max_tokens` parameters to the `KnowledgeBrainQA` constructor. These parameters allow for setting the maximum input length and maximum number of tokens for the KnowledgeBrainQA model. This provides more flexibility and control over the input size and tokenization process.