### PR TITLE
fix: ollama migration documentation

### DIFF
--- a/docs/developers/contribution/llm/ollama.mdx
+++ b/docs/developers/contribution/llm/ollama.mdx
@@ -20,7 +20,7 @@ ollama run llama2
 ### Run Migrations
 
 ```bash
-mv supabase/local_20240107152745_ollama.sql supabase/20240107152745_ollama.sql
+mv supabase/migrations/local_20240107152745_ollama.sql supabase/migrations/20240107152745_ollama.sql
 supabase db reset
 ```
 


### PR DESCRIPTION
# Description

https://github.com/QuivrHQ/quivr/blob/38de2e744049eea8c6cf85e4f5e9572c21083591/docs/developers/contribution/llm/ollama.mdx#L20-L25

Due to architectural changes in the file system, the ollama documentation is out of date.



The sql files are now nested inside a `migrations` directory instead of at the root of the supabase directory.

Fixed by adding `migrations` to the path 

```bash
mv supabase/migrations/local_20240107152745_ollama.sql supabase/migrations/20240107152745_ollama.sql
supabase db reset
```

## Checklist before requesting a review

Please delete options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] I have ideally added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

