### PR TITLE
Fix Sentry DSN environment variable

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 // Get the DSN from the environment variable
-const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const SENTRY_DSN = process.env.SENTRY_DSN;
 
 // Only initialize Sentry if the DSN is set
 if (SENTRY_DSN) {

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 // Get the DSN from the environment variable
-const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const SENTRY_DSN = process.env.SENTRY_DSN;
 
 // Only initialize Sentry if the DSN is set
 if (SENTRY_DSN) {

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 // Get the DSN from the environment variable
-const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const SENTRY_DSN = process.env.SENTRY_DSN;
 
 // Only initialize Sentry if the DSN is set
 if (SENTRY_DSN) {


### PR DESCRIPTION
Update the Sentry DSN environment variable to use the correct name. This ensures that Sentry is properly initialized when the DSN is set.