### PR TITLE
fix: Update Sentry configuration to use NEXT_PUBLIC_SENTRY_DSN

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # Sentry Config File
 .sentryclirc
+
+# Sentry Config File
+.sentryclirc

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 // Get the DSN from the environment variable
-const SENTRY_DSN = process.env.SENTRY_DSN;
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 // Only initialize Sentry if the DSN is set
 if (SENTRY_DSN) {

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 // Get the DSN from the environment variable
-const SENTRY_DSN = process.env.SENTRY_DSN;
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 // Only initialize Sentry if the DSN is set
 if (SENTRY_DSN) {

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 // Get the DSN from the environment variable
-const SENTRY_DSN = process.env.SENTRY_DSN;
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 // Only initialize Sentry if the DSN is set
 if (SENTRY_DSN) {


### PR DESCRIPTION
This pull request updates the Sentry configuration to use the `NEXT_PUBLIC_SENTRY_DSN` environment variable instead of `SENTRY_DSN`. This ensures that the correct DSN is used for Sentry initialization.