### PR TITLE
fix(rag): add api_base

### DIFF
--- a/backend/modules/brain/integrations/Big/Brain.py
+++ b/backend/modules/brain/integrations/Big/Brain.py
@@ -56,7 +56,11 @@ class BigBrain(KnowledgeBrainQA):
             template=question_prompt_template, input_variables=["context", "question"]
         )
 
-        llm = ChatLiteLLM(temperature=0, model=self.model)
+        api_base = None
+        if self.brain_settings.ollama_api_base_url and self.model.startswith("ollama"):
+            api_base = self.brain_settings.ollama_api_base_url
+
+        llm = ChatLiteLLM(temperature=0, model=self.model, api_base=api_base)
 
         retriever_doc = self.knowledge_qa.get_retriever()
 

--- a/backend/modules/brain/integrations/SQL/Brain.py
+++ b/backend/modules/brain/integrations/SQL/Brain.py
@@ -50,7 +50,11 @@ class SQLBrain(KnowledgeBrainQA, IntegrationBrain):
 
         self.db = SQLDatabase.from_uri(self.sql_connector.credentials["uri"])
 
-        model = ChatLiteLLM(model=self.model)
+        api_base = None
+        if self.brain_settings.ollama_api_base_url and self.model.startswith("ollama"):
+            api_base = self.brain_settings.ollama_api_base_url
+
+        model = ChatLiteLLM(model=self.model, api_base=api_base)
 
         sql_response = (
             RunnablePassthrough.assign(schema=self.get_schema)

--- a/backend/modules/brain/rags/quivr_rag.py
+++ b/backend/modules/brain/rags/quivr_rag.py
@@ -210,13 +210,17 @@ class QuivrRAG(BaseModel):
             | itemgetter("history"),
         )
 
+        api_base = None
+        if self.brain_settings.ollama_api_base_url and self.model.startswith("ollama"):
+            api_base = self.brain_settings.ollama_api_base_url
+
         standalone_question = {
             "standalone_question": {
                 "question": lambda x: x["question"],
                 "chat_history": lambda x: get_buffer_string(x["chat_history"]),
             }
             | CONDENSE_QUESTION_PROMPT
-            | ChatLiteLLM(temperature=0, model=self.model)
+            | ChatLiteLLM(temperature=0, model=self.model, api_base=api_base)
             | StrOutputParser(),
         }
 
@@ -242,7 +246,7 @@ class QuivrRAG(BaseModel):
         answer = {
             "answer": final_inputs
             | ANSWER_PROMPT
-            | ChatLiteLLM(max_tokens=self.max_tokens, model=self.model),
+            | ChatLiteLLM(max_tokens=self.max_tokens, model=self.model, api_base=api_base),
             "docs": itemgetter("docs"),
         }
 


### PR DESCRIPTION
# Description

With this pull request, I add a fix that **enables Ollama**. 

Running quivr in a Docker container, Ollama needs to be accessed via http://host.docker.internal:11434.

This URL is defined as `api_base` of the `ChatLiteLLM` constructor. But there are calls that are missing `api_base`. This leads to fallback URLs being used. This is now fixed.

Fixes #2270 #2267 #2217 #2204 

## Checklist before requesting a review

Please delete options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

## Screenshots (if appropriate):

None