### PR TITLE
feat: Add GPT3Brain class and integration in brainful_chat.py

### DIFF
--- a/backend/modules/brain/integrations/GPT3/Brain.py
+++ b/backend/modules/brain/integrations/GPT3/Brain.py
@@ -1,0 +1,71 @@
+import json
+from typing import AsyncIterable
+from uuid import UUID
+
+from langchain_community.chat_models import ChatLiteLLM
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from modules.brain.knowledge_brain_qa import KnowledgeBrainQA
+from modules.chat.dto.chats import ChatQuestion
+
+
+class GPT3Brain(KnowledgeBrainQA):
+    """This is the Notion brain class. it is a KnowledgeBrainQA has the data is stored locally.
+    It is going to call the Data Store internally to get the data.
+
+    Args:
+        KnowledgeBrainQA (_type_): A brain that store the knowledge internaly
+    """
+
+    def __init__(
+        self,
+        **kwargs,
+    ):
+        super().__init__(
+            **kwargs,
+        )
+
+    def calculate_pricing(self):
+        return 3
+
+    def get_chain(self):
+
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "You are GPT-3.5 powered by Quivr. You are an assistant. {custom_personality}",
+                ),
+                MessagesPlaceholder(variable_name="chat_history"),
+                ("human", "{question}"),
+            ]
+        )
+
+        chain = prompt | ChatLiteLLM(
+            model="gpt-3.5-turbo-0125", max_tokens=self.max_tokens
+        )
+
+        return chain
+
+    async def generate_stream(
+        self, chat_id: UUID, question: ChatQuestion, save_answer: bool = True
+    ) -> AsyncIterable:
+        conversational_qa_chain = self.get_chain()
+        transformed_history, streamed_chat_history = (
+            self.initialize_streamed_chat_history(chat_id, question)
+        )
+        response_tokens = []
+
+        async for chunk in conversational_qa_chain.astream(
+            {
+                "question": question.question,
+                "chat_history": transformed_history,
+                "custom_personality": (
+                    self.prompt_to_use.content if self.prompt_to_use else None
+                ),
+            }
+        ):
+            response_tokens.append(chunk.content)
+            streamed_chat_history.assistant = chunk.content
+            yield f"data: {json.dumps(streamed_chat_history.dict())}"
+
+        self.save_answer(question, response_tokens, streamed_chat_history, save_answer)

--- a/backend/modules/chat/controller/chat/brainful_chat.py
+++ b/backend/modules/chat/controller/chat/brainful_chat.py
@@ -2,6 +2,7 @@ from logger import get_logger
 from modules.brain.api_brain_qa import APIBrainQA
 from modules.brain.entity.brain_entity import BrainType, RoleEnum
 from modules.brain.integrations.Big.Brain import BigBrain
+from modules.brain.integrations.GPT3.Brain import GPT3Brain
 from modules.brain.integrations.GPT4.Brain import GPT4Brain
 from modules.brain.integrations.Notion.Brain import NotionBrain
 from modules.brain.integrations.SQL.Brain import SQLBrain
@@ -40,6 +41,7 @@ integration_list = {
     "gpt4": GPT4Brain,
     "sql": SQLBrain,
     "big": BigBrain,
+    "gpt3": GPT3Brain,
 }
 
 brain_service = BrainService()


### PR DESCRIPTION
This pull request adds the GPT3Brain class and its integration in the brainful_chat.py file. The GPT3Brain class is a subclass of KnowledgeBrainQA and is responsible for handling the GPT-3.5 powered assistant functionality. It includes methods for calculating pricing and generating a conversational stream. The brainful_chat.py file is also updated to import the GPT3Brain class and include it in the brain_service dictionary.