### PR TITLE
feat: Add optional fields to UserIdentity and UserUpdatableProperties

### DIFF
--- a/backend/modules/user/dto/inputs.py
+++ b/backend/modules/user/dto/inputs.py
@@ -1,6 +1,10 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 
 class UserUpdatableProperties(BaseModel):
     # Nothing for now
-    empty: bool = True
+    username: Optional[str] = None
+    company: Optional[str] = None
+    onboarded: Optional[bool] = None

--- a/backend/modules/user/entity/user_identity.py
+++ b/backend/modules/user/entity/user_identity.py
@@ -7,3 +7,6 @@ from pydantic import BaseModel
 class UserIdentity(BaseModel):
     id: UUID
     email: Optional[str] = None
+    username: Optional[str] = None
+    company: Optional[str] = None
+    onboarded: Optional[bool] = None

--- a/backend/modules/user/repository/users.py
+++ b/backend/modules/user/repository/users.py
@@ -44,7 +44,7 @@ class Users(UsersInterface):
     def get_user_identity(self, user_id):
         response = (
             self.db.from_("user_identity")
-            .select("*")
+            .select("*, users (email)")
             .filter("user_id", "eq", str(user_id))
             .execute()
         )
@@ -53,8 +53,10 @@ class Users(UsersInterface):
             return self.create_user_identity(user_id)
 
         user_identity = response.data[0]
-        print("USER_IDENTITY", user_identity)
-        return UserIdentity(id=user_id)
+
+        user_identity["id"] = user_id  # Add 'id' field to the dictionary
+        user_identity["email"] = user_identity["users"]["email"]
+        return UserIdentity(**user_identity)
 
     def get_user_id_by_user_email(self, email):
         response = (

--- a/supabase/migrations/20240313024244_onboarding-user.sql
+++ b/supabase/migrations/20240313024244_onboarding-user.sql
@@ -1,0 +1,15 @@
+alter table "public"."user_identity" drop constraint "user_identity_user_id_fkey";
+
+alter table "public"."user_identity" add column "company" text;
+
+alter table "public"."user_identity" add column "onboarded" boolean not null default false;
+
+alter table "public"."user_identity" add column "username" text;
+
+alter table "public"."users" add column "onboarded" boolean not null default false;
+
+alter table "public"."user_identity" add constraint "public_user_identity_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+
+alter table "public"."user_identity" validate constraint "public_user_identity_user_id_fkey";
+
+


### PR DESCRIPTION
This pull request adds optional fields to the UserIdentity and UserUpdatableProperties classes in order to allow for more flexibility when updating user properties. The new fields include username, company, and onboarded. Additionally, the database schema has been updated to reflect these changes.