### PR TITLE
fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can find the installation video [here](https://www.youtube.com/watch?v=cXBa6
 - **Step 1**: Clone the repository:
 
   ```bash
-  git clone https://github.com/quivrhq/quivr.git && cd Quivr
+  git clone https://github.com/quivrhq/quivr.git && cd quivr
   ```
 
 - **Step 2**: Copy the `.env.example` files


### PR DESCRIPTION
# Description

Readme has a typo in step 1 for the directory name to `cd` into

## Checklist before requesting a review

Please delete options that are not relevant.

## Screenshots (if appropriate):
