### PR TITLE
feat: Add url_required field to IngestionEntity

### DIFF
--- a/backend/modules/ingestion/entity/ingestion.py
+++ b/backend/modules/ingestion/entity/ingestion.py
@@ -8,3 +8,4 @@ class IngestionEntity(BaseModel):
     name: str
     brain_id_required: bool
     file_1_required: bool
+    url_required: bool


### PR DESCRIPTION
This pull request adds a new field, `url_required`, to the `IngestionEntity` class. This field is required for the ingestion process and will be used to store the URL of the entity.