### PR TITLE
Persist user-selected language across sessions

### DIFF
--- a/frontend/app/user/components/LanguageSelect/hooks/useLanguageHook.ts
+++ b/frontend/app/user/components/LanguageSelect/hooks/useLanguageHook.ts
@@ -57,10 +57,13 @@ export const useLanguageHook = (): {
     const savedLanguage = localStorage.getItem("selectedLanguage") ?? "English";
 
     setCurrentLanguage(
-      languages.find((language) => language.label === savedLanguage)
+        languages.find((language) => language.label === savedLanguage)
     );
-    void i18n.changeLanguage(savedLanguage);
-  }, [i18n]);
+    var shortName = languages.find(
+        (language) => language.label === savedLanguage
+    )?.shortName;
+    void i18n.changeLanguage(shortName);
+}, [i18n]);
 
   const change = (newLanguage: Language) => {
     void track("CHANGE_LANGUAGE");


### PR DESCRIPTION
Changed the mechanism for retrieving the user's selected language. Instead of directly setting the language in the i18n configuration, the updated code now fetches the short name of the language based on the savedLanguage value. This short name is then used to persistently set the user's preferred language across platform sessions, ensuring that the language preference is retained even after a refresh. This update addresses the issue where the platform would revert to English on every refresh, disregarding the user's previously selected language preference.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
