### PR TITLE
feat: Add tags to AssistantOutput classes

### DIFF
--- a/backend/modules/assistant/dto/outputs.py
+++ b/backend/modules/assistant/dto/outputs.py
@@ -47,6 +47,7 @@ class Outputs(BaseModel):
 
 class AssistantOutput(BaseModel):
     name: str
+    tags: Optional[List[str]] = []
     input_description: str
     output_description: str
     inputs: Inputs

--- a/backend/modules/assistant/ito/audio_transcript.py
+++ b/backend/modules/assistant/ito/audio_transcript.py
@@ -59,6 +59,7 @@ def audio_transcript_inputs():
     output = AssistantOutput(
         name="Audio Transcript",
         description="Transcribes an audio file",
+        tags=["new"],
         input_description="One audio file to transcribe",
         output_description="Transcription of the audio file",
         inputs=Inputs(

--- a/backend/modules/assistant/ito/crawler.py
+++ b/backend/modules/assistant/ito/crawler.py
@@ -45,6 +45,7 @@ def crawler_inputs():
     output = AssistantOutput(
         name="Crawler",
         description="Crawls a website and extracts the text from the pages",
+        tags=["new"],
         input_description="One URL to crawl",
         output_description="Text extracted from the pages",
         inputs=Inputs(

--- a/backend/modules/assistant/ito/summary.py
+++ b/backend/modules/assistant/ito/summary.py
@@ -141,6 +141,7 @@ def summary_inputs():
     output = AssistantOutput(
         name="Summary",
         description="Summarize a set of documents",
+        tags=["new"],
         input_description="One document to summarize",
         output_description="A summary of the document",
         inputs=Inputs(


### PR DESCRIPTION
This pull request adds a new optional field "tags" to the AssistantOutput classes. The "tags" field allows for categorizing the outputs and can be used for filtering or organizing purposes.