### PR TITLE
feat: Add filename to page content in embedding

### DIFF
--- a/backend/packages/files/parsers/common.py
+++ b/backend/packages/files/parsers/common.py
@@ -41,6 +41,8 @@ async def process_file(
     if file.documents is not None:
         for doc in file.documents:  # pyright: ignore reportPrivateUsage=none
             new_metadata = metadata.copy()
+            # Add filename at beginning of page content
+            doc.page_content = f"Filename: {new_metadata['original_file_name']} Content: {doc.page_content}"
             len_chunk = len(enc.encode(doc.page_content))
             page_content_encoded = doc.page_content.encode("unicode_escape").decode(
                 "ascii", "replace"


### PR DESCRIPTION
This pull request adds the filename to the beginning of the page content in the embedding feature. This change allows for easier identification of the file when viewing the embedded content.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6a691d36d0f544c600b6dadc3ddac3b9b73de82d.  | 
|--------|--------|

### Summary:
This PR modifies the `process_file` function in `/backend/packages/files/parsers/common.py` to prepend the filename to the page content in the embedding feature for easier file identification.

**Key points**:
- Modified `process_file` function in `/backend/packages/files/parsers/common.py`.
- Added filename to the beginning of `doc.page_content`.
- Filename is retrieved from `new_metadata['original_file_name']`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
