### PR TITLE
feat(assistant): check if key of file is same as filename uploaded

### DIFF
--- a/backend/modules/assistant/ito/summary.py
+++ b/backend/modules/assistant/ito/summary.py
@@ -57,6 +57,11 @@ class SummaryAssistant(ITO):
             raise ValueError("The key of the file should be doc_to_summarize")
         if not self.input.inputs.files[0].value:
             raise ValueError("No file was uploaded")
+        # Check if name of file is same as the key
+        if not self.input.inputs.files[0].value == self.files[0].filename:
+            raise ValueError(
+                "The key of the file should be the same as the name of the file"
+            )
         if not (
             self.input.outputs.brain.activated or self.input.outputs.email.activated
         ):


### PR DESCRIPTION
This pull request fixes the file key validation in the `check_input` method. Previously, the method only checked if a file was uploaded and if the key of the file was "doc_to_summarize". However, it did not check if the key of the file was the same as the name of the file. This PR adds a check to ensure that the key of the file is the same as the name of the file. This improves the accuracy of the file validation process.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8f04d832ac1a8c7188c71620f20be2319c472cfd.  | 
|--------|--------|

### Summary:
This PR enhances the file validation process in the `SummaryAssistant` class by ensuring the key of the uploaded file matches its filename.

**Key points**:
- Added a new file key validation in `check_input` method of `SummaryAssistant` class.
- The validation checks if the key of the uploaded file matches the filename.
- This is an additional check to the existing file upload and key validations.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
