### PR TITLE
fix(assistant): summary now can output 2000 tokens

### DIFF
--- a/backend/modules/assistant/ito/summary.py
+++ b/backend/modules/assistant/ito/summary.py
@@ -85,7 +85,7 @@ class SummaryAssistant(ITO):
 
         data = loader.load()
 
-        llm = ChatLiteLLM(model="gpt-3.5-turbo")
+        llm = ChatLiteLLM(model="gpt-3.5-turbo", max_tokens=2000)
 
         map_template = """The following is one document to summarize that has been split into multiple sections:
         {docs}


### PR DESCRIPTION
This pull request increases the token limit for the summary output to 2000 in order to accommodate larger documents.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4412ecde83c4bc158dc56619c959288957ac3b4c.  | 
|--------|--------|

### Summary:
This PR increases the token limit for the summary output to 2000 in the `SummaryAssistant` class to accommodate larger documents.

**Key points**:
- Increased `max_tokens` parameter in `ChatLiteLLM` instance to 2000 in `process_assistant` function of `SummaryAssistant` class in `/backend/modules/assistant/ito/summary.py` file.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
