### PR TITLE
fix(assistants): brain id is null

### DIFF
--- a/backend/modules/assistant/dto/inputs.py
+++ b/backend/modules/assistant/dto/inputs.py
@@ -2,7 +2,7 @@ import json
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, model_validator, root_validator
 
 
 class EmailInput(BaseModel):
@@ -10,8 +10,15 @@ class EmailInput(BaseModel):
 
 
 class BrainInput(BaseModel):
-    activated: bool
-    value: UUID
+    activated: Optional[bool] = False
+    value: Optional[UUID] = None
+
+    @root_validator(pre=True)
+    def empty_string_to_none(cls, values):
+        for field, value in values.items():
+            if value == "":
+                values[field] = None
+        return values
 
 
 class FileInput(BaseModel):


### PR DESCRIPTION
This pull request fixes an issue where the brain activation and value handling were not working correctly. The `BrainInput` model now allows for optional activation and value fields, and an empty string is converted to `None` using a root validator. This ensures that brain activation and value can be properly handled in the application.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d63ed6e651d40d3a18ddbc265d8166fddb18cf98  | 
|--------|

### Summary:
This PR modifies the `BrainInput` class in `/backend/modules/assistant/dto/inputs.py` to make `activated` and `value` fields optional and adds a root validator to convert empty strings to `None`.

**Key points**:
- Modified `BrainInput` class in `/backend/modules/assistant/dto/inputs.py`
- Made `activated` and `value` fields optional with default values
- Added root validator `empty_string_to_none` to convert empty strings to `None`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
