### PR TITLE
feat(aws): Update CPU and memory configurations for task definitions

### DIFF
--- a/.aws/task_definition.json
+++ b/.aws/task_definition.json
@@ -4,8 +4,8 @@
     {
       "name": "quivr",
       "image": "253053805092.dkr.ecr.eu-west-3.amazonaws.com/quivr:bada136312ad3497664c3562a36b263d43c89c53",
-      "cpu": "2048",
-      "memory": "8192",
+      "cpu": "1024",
+      "memory": "2048",
       "portMappings": [
         {
           "name": "quivr-5050-tcp",
@@ -88,8 +88,8 @@
   "placementConstraints": [],
   "compatibilities": ["EC2", "FARGATE"],
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "2048",
-  "memory": "8192",
+  "cpu": "1024",
+  "memory": "2048",
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"

--- a/.aws/task_definition_preview.json
+++ b/.aws/task_definition_preview.json
@@ -4,8 +4,8 @@
     {
       "name": "quivr",
       "image": "253053805092.dkr.ecr.eu-west-3.amazonaws.com/quivr:c0ff0301002fe6d043270b26dabcfda797437afc",
-      "cpu": "2048",
-      "memory": "8192",
+      "cpu": "1024",
+      "memory": "2048",
       "portMappings": [
         {
           "name": "quivr-5050-tcp",
@@ -89,8 +89,8 @@
   "placementConstraints": [],
   "compatibilities": ["EC2", "FARGATE"],
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "2048",
-  "memory": "8192",
+  "cpu": "1024",
+  "memory": "2048",
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"

--- a/.aws/task_definition_preview_beat.json
+++ b/.aws/task_definition_preview_beat.json
@@ -4,8 +4,8 @@
     {
       "name": "quivr-beat",
       "image": "253053805092.dkr.ecr.eu-west-3.amazonaws.com/quivr:600ff1ede02741c66853cc3e4e7f5001aaba3bc2",
-      "cpu": "2048",
-      "memory": "4096",
+      "cpu": "256",
+      "memory": "512",
       "essential": true,
       "command": ["celery", "-A", "celery_worker", "beat", "-l", "info"],
 
@@ -71,8 +71,8 @@
   "placementConstraints": [],
   "compatibilities": ["EC2", "FARGATE"],
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "2048",
-  "memory": "4096",
+  "cpu": "256",
+  "memory": "512",
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"

--- a/.aws/task_definition_preview_worker.json
+++ b/.aws/task_definition_preview_worker.json
@@ -4,8 +4,8 @@
     {
       "name": "quivr-chat",
       "image": "253053805092.dkr.ecr.eu-west-3.amazonaws.com/quivr:600ff1ede02741c66853cc3e4e7f5001aaba3bc2",
-      "cpu": "4096",
-      "memory": "8192",
+      "cpu": "2048",
+      "memory": "4096",
       "essential": true,
       "command": ["celery", "-A", "celery_worker", "worker", "-l", "info"],
       "environment": [],
@@ -70,8 +70,8 @@
   "placementConstraints": [],
   "compatibilities": ["EC2", "FARGATE"],
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "4096",
-  "memory": "8192",
+  "cpu": "2048",
+  "memory": "4096",
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"

--- a/.aws/task_definition_prod_worker.json
+++ b/.aws/task_definition_prod_worker.json
@@ -4,9 +4,9 @@
     {
       "name": "quivr-chat",
       "image": "253053805092.dkr.ecr.eu-west-3.amazonaws.com/quivr:35bd4727c67790d295a474dd81dfbef8469365e8",
-      "cpu": "4096",
-      "memory": "8192",
-      "memoryReservation": 8192,
+      "cpu": "2048",
+      "memory": "4096",
+      "memoryReservation": 4096,
       "portMappings": [],
       "essential": true,
       "command": ["celery", "-A", "celery_worker", "worker", "-l", "info"],
@@ -76,8 +76,8 @@
   "placementConstraints": [],
   "compatibilities": ["EC2", "FARGATE"],
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "4096",
-  "memory": "8192",
+  "cpu": "2048",
+  "memory": "4096",
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"


### PR DESCRIPTION
This pull request updates the CPU and memory configurations for the task definitions in the AWS service. The CPU has been changed from 2048 to 1024, and the memory has been changed from 8192 to 2048. These changes optimize the resource allocation for the task definitions.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c0951798182a0202b020aefbbaff50d3b30a88d9  | 
|--------|

### Summary:
This PR optimizes resource allocation by reducing CPU and memory configurations for task definitions in five AWS service JSON files.

**Key points**:
- Reduced CPU and memory configurations in `task_definition.json`, `task_definition_preview.json`, `task_definition_preview_beat.json`, `task_definition_preview_worker.json`, and `task_definition_prod_worker.json`.
- Optimized resource allocation for task definitions.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
