### PR TITLE
Update CPU and memory settings in task definition files

### DIFF
--- a/.aws/task_definition.json
+++ b/.aws/task_definition.json
@@ -4,8 +4,8 @@
     {
       "name": "quivr",
       "image": "253053805092.dkr.ecr.eu-west-3.amazonaws.com/quivr:bada136312ad3497664c3562a36b263d43c89c53",
-      "cpu": "1024",
-      "memory": "2048",
+      "cpu": "2048",
+      "memory": "4096",
       "portMappings": [
         {
           "name": "quivr-5050-tcp",
@@ -88,8 +88,8 @@
   "placementConstraints": [],
   "compatibilities": ["EC2", "FARGATE"],
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "1024",
-  "memory": "2048",
+  "cpu": "2048",
+  "memory": "4096",
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"

--- a/.aws/task_definition_preview.json
+++ b/.aws/task_definition_preview.json
@@ -4,8 +4,8 @@
     {
       "name": "quivr",
       "image": "253053805092.dkr.ecr.eu-west-3.amazonaws.com/quivr:c0ff0301002fe6d043270b26dabcfda797437afc",
-      "cpu": "1024",
-      "memory": "2048",
+      "cpu": "2048",
+      "memory": "4096",
       "portMappings": [
         {
           "name": "quivr-5050-tcp",
@@ -89,8 +89,8 @@
   "placementConstraints": [],
   "compatibilities": ["EC2", "FARGATE"],
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "1024",
-  "memory": "2048",
+  "cpu": "2048",
+  "memory": "4096",
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"


### PR DESCRIPTION
This pull request updates the CPU and memory settings in the task definition files for the AWS service. The CPU has been increased from 1024 to 2048, and the memory has been increased from 2048 to 4096. This change ensures that the service has enough resources to handle the workload efficiently.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1bc415aa66edfa84d60ab23d81e6f0695e56a85d  | 
|--------|

### Summary:
This PR enhances the AWS service's resource allocation by doubling the CPU and memory settings in the task definition files.

**Key points**:
- Updated CPU and memory settings in `/.aws/task_definition.json` and `/.aws/task_definition_preview.json`.
- CPU value increased from 1024 to 2048.
- Memory value increased from 2048 to 4096.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
