### PR TITLE
docs: Update links in mint.json to add api

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -28,9 +28,9 @@
       "url": "https://discord.gg/HUpRgp2HG8"
     },
     {
-      "name": "Blog",
-      "icon": "newspaper",
-      "url": "https://quivr.app/blog"
+      "name": "API Docs",
+      "icon": "globe",
+      "url": "https://api.quivr.app/docs"
     },
     {
       "name": "Status",


### PR DESCRIPTION
This pull request updates the links in the mint.json file to include a link to the API documentation. The "Blog" link has been replaced with an "API Docs" link that points to https://api.quivr.app/docs.