### PR TITLE
fix(metadata): Removed citation from metadata

### DIFF
--- a/backend/modules/brain/knowledge_brain_qa.py
+++ b/backend/modules/brain/knowledge_brain_qa.py
@@ -272,7 +272,6 @@ class KnowledgeBrainQA(BaseModel, QAInterface):
                 if citations:
                     citations = citations
                 answer = model_response["answer"].tool_calls[-1]["args"]["answer"]
-                metadata["citations"] = citations
         else:
             answer = model_response["answer"].content
         sources = model_response["docs"] or []
@@ -342,8 +341,6 @@ class KnowledgeBrainQA(BaseModel, QAInterface):
                 sources = chunk["docs"]
 
         sources_list = generate_source(sources, self.brain_id, citations)
-
-        streamed_chat_history.metadata["citations"] = citations
 
         # Serialize the sources list
         serialized_sources_list = [source.dict() for source in sources_list]


### PR DESCRIPTION
This pull request removes the citation metadata from the generate_answer and generate_stream functions. The citation metadata was previously being added to the streamed_chat_history and metadata dictionaries, but it is no longer necessary. This change improves the efficiency and clarity of the code.