### PR TITLE
feat(llamaparse): Add Llama Parse integration for complex document parsing

### DIFF
--- a/docs/configuring/llamaparse.mdx
+++ b/docs/configuring/llamaparse.mdx
@@ -1,0 +1,28 @@
+---
+title: Llama Parse
+description: Use Llama Parse to read complex document in Quivr
+---
+
+
+# Llama Parse
+
+Llama Parse is a tool from Llama Index that allows you to read complex documents in Quivr.
+
+Link to Llama Parse: [https://cloud.llamaindex.ai/parse](https://cloud.llamaindex.ai/parse)
+
+## How to use Llama Parse
+
+1. Go to [https://cloud.llamaindex.ai/parse](https://cloud.llamaindex.ai/parse)
+
+2. Create an API key by clicking on the `Create API Key` button.
+
+3. Add `LLAMA_CLOUD_API_KEY` to your `.env` file.
+
+```bash
+# Llama Parse Configuration
+LLAMA_CLOUD_API_KEY=your_llama_cloud_api_key
+```
+
+4. Use the Llama Parse tool to read complex documents in Quivr - Currently only supports `pdf`, `docx`, and `doc` files.
+
+

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -66,6 +66,7 @@
             "configuring/increase-user-usage",
             "configuring/resend-emails",
             "configuring/reranking",
+            "configuring/llamaparse",
             "configuring/environment-variables",
             "configuring/profiler",
             "configuring/telemetry"


### PR DESCRIPTION
This pull request adds Llama Parse integration for complex document parsing in Quivr. Llama Parse is a tool from Llama Index that allows you to read complex documents in Quivr. It provides an API key that needs to be added to the `.env` file as `LLAMA_CLOUD_API_KEY`. Once configured, you can use the Llama Parse tool to read `pdf`, `docx`, and `doc` files in Quivr.