### PR TITLE
Fix: citation handling in ChatItem component

### DIFF
--- a/frontend/app/chat/[chatId]/components/ChatDialogueArea/components/ChatDialogue/components/ChatItem/QADisplay/components/MessageRow/components/Citation/Citation.tsx
+++ b/frontend/app/chat/[chatId]/components/ChatDialogueArea/components/ChatDialogue/components/ChatItem/QADisplay/components/MessageRow/components/Citation/Citation.tsx
@@ -11,8 +11,14 @@ export const Citation = ({ citation }: CitationProps): JSX.Element => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   const contentIndex = citation.indexOf("Content:");
-  const cleanedCitation = citation.substring(contentIndex);
-  const [, content] = cleanedCitation.split("Content:");
+  let cleanedCitation, content;
+
+  if (contentIndex !== -1) {
+    cleanedCitation = citation.substring(contentIndex);
+    [, content] = cleanedCitation.split("Content:");
+  } else {
+    content = citation;
+  }
 
   const handleIconClick = (event: React.MouseEvent) => {
     event.stopPropagation();


### PR DESCRIPTION
This pull request fixes the citation handling in the ChatItem component. Previously, if the citation did not contain the word "Content:", the component would throw an error. This PR adds a check for the presence of "Content:" in the citation and handles it accordingly.