### PR TITLE
Add config parameter to conversational_qa_chain

### DIFF
--- a/backend/modules/brain/integrations/GPT4/Brain.py
+++ b/backend/modules/brain/integrations/GPT4/Brain.py
@@ -61,6 +61,7 @@ class GPT4Brain(KnowledgeBrainQA):
             self.initialize_streamed_chat_history(chat_id, question)
         )
         response_tokens = []
+        config = {"metadata": {"conversation_id": str(chat_id)}}
 
         async for chunk in conversational_qa_chain.astream(
             {
@@ -69,7 +70,8 @@ class GPT4Brain(KnowledgeBrainQA):
                 "custom_personality": (
                     self.prompt_to_use.content if self.prompt_to_use else None
                 ),
-            }
+            },
+            config=config,
         ):
             response_tokens.append(chunk.content)
             streamed_chat_history.assistant = chunk.content

--- a/backend/modules/brain/integrations/Proxy/Brain.py
+++ b/backend/modules/brain/integrations/Proxy/Brain.py
@@ -55,6 +55,7 @@ class ProxyBrain(KnowledgeBrainQA):
             self.initialize_streamed_chat_history(chat_id, question)
         )
         response_tokens = []
+        config = {"metadata": {"conversation_id": str(chat_id)}}
 
         async for chunk in conversational_qa_chain.astream(
             {
@@ -63,7 +64,8 @@ class ProxyBrain(KnowledgeBrainQA):
                 "custom_personality": (
                     self.prompt_to_use.content if self.prompt_to_use else None
                 ),
-            }
+            },
+            config=config,
         ):
             response_tokens.append(chunk.content)
             streamed_chat_history.assistant = chunk.content
@@ -78,6 +80,7 @@ class ProxyBrain(KnowledgeBrainQA):
         transformed_history, streamed_chat_history = (
             self.initialize_streamed_chat_history(chat_id, question)
         )
+        config = {"metadata": {"conversation_id": str(chat_id)}}
         model_response = conversational_qa_chain.invoke(
             {
                 "question": question.question,
@@ -85,7 +88,8 @@ class ProxyBrain(KnowledgeBrainQA):
                 "custom_personality": (
                     self.prompt_to_use.content if self.prompt_to_use else None
                 ),
-            }
+            },
+            config=config,
         )
 
         answer = model_response.content

--- a/backend/modules/brain/knowledge_brain_qa.py
+++ b/backend/modules/brain/knowledge_brain_qa.py
@@ -255,6 +255,8 @@ class KnowledgeBrainQA(BaseModel, QAInterface):
         metadata = self.metadata or {}
         citations = None
         answer = ""
+        config = {"metadata": {"conversation_id": str(chat_id)}}
+
         model_response = conversational_qa_chain.invoke(
             {
                 "question": question.question,
@@ -262,7 +264,8 @@ class KnowledgeBrainQA(BaseModel, QAInterface):
                 "custom_personality": (
                     self.prompt_to_use.content if self.prompt_to_use else None
                 ),
-            }
+            },
+            config=config,
         )
 
         if self.model_compatible_with_function_calling(model=self.model):
@@ -294,6 +297,8 @@ class KnowledgeBrainQA(BaseModel, QAInterface):
         sources = []
         citations = []
         first = True
+        config = {"metadata": {"conversation_id": str(chat_id)}}
+
         async for chunk in conversational_qa_chain.astream(
             {
                 "question": question.question,
@@ -301,7 +306,8 @@ class KnowledgeBrainQA(BaseModel, QAInterface):
                 "custom_personality": (
                     self.prompt_to_use.content if self.prompt_to_use else None
                 ),
-            }
+            },
+            config=config,
         ):
             if not streamed_chat_history.metadata:
                 streamed_chat_history.metadata = {}

--- a/frontend/lib/hooks/useAuthModes.ts
+++ b/frontend/lib/hooks/useAuthModes.ts
@@ -4,9 +4,6 @@ export const useAuthModes = () => {
     "password",
   ];
 
-  console.log('Environment Variable NEXT_PUBLIC_AUTH_MODES:', process.env.NEXT_PUBLIC_AUTH_MODES);
-  console.log('authModes:', authModes);
-
   return {
     magicLink: authModes.includes("magic_link"),
     password: authModes.includes("password"),


### PR DESCRIPTION
This pull request adds a new config parameter to the `conversational_qa_chain` function. The config parameter allows for passing metadata, specifically the conversation ID, to the function. This change ensures that the conversation ID is included in the metadata when invoking the `conversational_qa_chain` function.