### PR TITLE
Add Docker image build and push workflow

### DIFF
--- a/.github/workflows/prebuild-images.yml
+++ b/.github/workflows/prebuild-images.yml
@@ -1,0 +1,69 @@
+name: Prebuild & Deploy Docker Images
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "backend/**"
+
+env:
+  AWS_REGION: eu-west-3
+  ECR_REPOSITORY: backend
+  ECR_REGISTRY: public.ecr.aws/c2l8c5w6
+
+jobs:
+  build_and_push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+
+      - name: Create Docker Cacha Storage Backend
+        run: |
+          docker buildx create --use --driver=docker-container
+      - name: See the file in the runner
+        run: |
+          ls -la
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        with:
+          context: ./backend/
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}, ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest, ghcr.io/quivrhq/quivr:latest, stangirard/quivr-backend-prebuilt:latest, stangirard/quivr-backend-prebuilt:${{ env.IMAGE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/backend/celery_worker.py
+++ b/backend/celery_worker.py
@@ -150,6 +150,7 @@ def process_crawl_and_notify(
                 description="Your file has been properly uploaded!",
             ),
         )
+
     brain_service.update_brain_last_update_time(brain_id)
     return True
 


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow for building and pushing Docker images to Amazon ECR. The workflow is triggered on every push to the main branch and includes steps for configuring AWS credentials, logging in to Amazon ECR, GitHub Container Registry, and Docker Hub, setting up Docker Buildx, creating a Docker cache storage backend, and building, tagging, and pushing the Docker image to Amazon ECR.