### PR TITLE
fix:  sender email address in resend_invitation_email.py

### DIFF
--- a/backend/modules/brain/service/brain_subscription/resend_invitation_email.py
+++ b/backend/modules/brain/service/brain_subscription/resend_invitation_email.py
@@ -41,7 +41,7 @@ def resend_invitation_email(
     try:
         r = send_email(
             {
-                "from": brains_settings.resend_email_address,
+                "sender": brains_settings.resend_email_address,
                 "to": brain_subscription.email,
                 "subject": "Quivr - Brain Shared With You",
                 "html": html_body,


### PR DESCRIPTION
This pull request fixes the sender email address in the `resend_invitation_email` function in the `resend_invitation_email.py` file. The `from` field has been changed to `sender` to ensure that the correct email address is used when sending the invitation email.