### PR TITLE
feat: Add force_sync option to SyncsActiveUpdateInput

### DIFF
--- a/backend/modules/sync/dto/inputs.py
+++ b/backend/modules/sync/dto/inputs.py
@@ -78,6 +78,7 @@ class SyncsActiveUpdateInput(BaseModel):
     name: Optional[str] = None
     settings: Optional[SyncActiveSettings] = None
     last_synced: Optional[str] = None
+    force_sync: Optional[bool] = False
 
 
 class SyncFileInput(BaseModel):

--- a/backend/modules/sync/repository/sync.py
+++ b/backend/modules/sync/repository/sync.py
@@ -93,6 +93,7 @@ class Sync(SyncInterface):
             sync_id,
             sync_active_input,
         )
+
         response = (
             self.db.from_("syncs_active")
             .update(sync_active_input.model_dump(exclude_unset=True))
@@ -185,12 +186,13 @@ class Sync(SyncInterface):
             .lt("last_synced", (current_time - timedelta(minutes=360)).isoformat())
             .execute()
         )
-        if response.data:
-            logger.info("Active syncs retrieved successfully: %s", response.data)
-            for sync in response.data:
-                # Now we can call the sync_google_drive_if_not_synced method to sync the Google Drive files
-                logger.info("Syncing Google Drive for sync_active_id: %s", sync["id"])
 
-            return [SyncsActive(**sync) for sync in response.data]
-        logger.warning("No active syncs found due for synchronization")
+        force_sync = (
+            self.db.table("syncs_active").select("*").eq("force_sync", True).execute()
+        )
+        merge_data = response.data + force_sync.data
+        if merge_data:
+            logger.info("Active syncs retrieved successfully: %s", merge_data)
+            return [SyncsActive(**sync) for sync in merge_data]
+        logger.info("No active syncs found due for synchronization")
         return []

--- a/backend/modules/sync/utils/googleutils.py
+++ b/backend/modules/sync/utils/googleutils.py
@@ -216,8 +216,9 @@ class GoogleSyncUtils(BaseModel):
 
         # Check if the sync is due
         last_synced = sync_active.get("last_synced")
+        force_sync = sync_active.get("force_sync", False)
         sync_interval_minutes = sync_active.get("sync_interval_minutes", 0)
-        if last_synced:
+        if last_synced and not force_sync:
             last_synced_time = datetime.fromisoformat(last_synced).astimezone(
                 timezone.utc
             )
@@ -318,7 +319,10 @@ class GoogleSyncUtils(BaseModel):
         # Update the last_synced timestamp
         self.sync_active_service.update_sync_active(
             sync_active_id,
-            SyncsActiveUpdateInput(last_synced=datetime.now().astimezone().isoformat()),
+            SyncsActiveUpdateInput(
+                last_synced=datetime.now().astimezone().isoformat(),
+                force_sync=False,
+            ),
         )
         logger.info(
             "Google Drive sync completed for sync_active_id: %s", sync_active_id

--- a/backend/modules/sync/utils/sharepointutils.py
+++ b/backend/modules/sync/utils/sharepointutils.py
@@ -209,8 +209,9 @@ class AzureSyncUtils(BaseModel):
 
         # Check if the sync is due
         last_synced = sync_active.get("last_synced")
+        force_sync = sync_active.get("force_sync", False)
         sync_interval_minutes = sync_active.get("sync_interval_minutes", 0)
-        if last_synced:
+        if last_synced and not force_sync:
             last_synced_time = datetime.fromisoformat(last_synced).astimezone(
                 timezone.utc
             )
@@ -326,7 +327,9 @@ class AzureSyncUtils(BaseModel):
         # Update the last_synced timestamp
         self.sync_active_service.update_sync_active(
             sync_active_id,
-            SyncsActiveUpdateInput(last_synced=datetime.now().astimezone().isoformat()),
+            SyncsActiveUpdateInput(
+                last_synced=datetime.now().astimezone().isoformat(), force_sync=False
+            ),
         )
         logger.info("Azure sync completed for sync_active_id: %s", sync_active_id)
         return downloaded_files

--- a/backend/supabase/migrations/20240610141546_force-sync.sql
+++ b/backend/supabase/migrations/20240610141546_force-sync.sql
@@ -1,0 +1,1 @@
+alter table "public"."syncs_active" add column "force_sync" boolean not null default false;


### PR DESCRIPTION
This commit adds a new optional boolean field, force_sync, to the SyncsActiveUpdateInput class in the sync module. The force_sync field allows users to manually trigger a sync operation, bypassing the regular sync interval. By default, force_sync is set to False.

The force_sync field is used in the GoogleSyncUtils and AzureSyncUtils classes to determine whether to perform a sync operation even if the regular sync interval has not elapsed. If force_sync is True, the last_synced timestamp is updated and the sync operation is executed.

This enhancement provides more flexibility and control over the synchronization process, allowing users to manually trigger sync operations when needed.