### PR TITLE
Update license to include enterprise features

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -127,6 +127,13 @@
       reproduction, and distribution of the Work otherwise complies with
       the conditions stated in this License.
 
+      (e) Some folders or files within the distribution may be subject to
+          different license terms and conditions. In such cases, the
+          applicable license will be specified in a separate LICENSE file
+          or within the file itself. You must comply with the terms of
+          these additional licenses when using, reproducing, or distributing
+          those specific folders or files.
+
    5. Submission of Contributions. Unless You explicitly state otherwise,
       any Contribution intentionally submitted for inclusion in the Work
       by You to the Licensor shall be under the terms and conditions of
@@ -186,7 +193,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2023] [StanGirard]
+   Copyright [2023-2024] [Quivr]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/backend/modules/sync/utils/LICENSE
+++ b/backend/modules/sync/utils/LICENSE
@@ -1,0 +1,36 @@
+The Quivr Enterprise license (the “Enterprise License”)
+Copyright (c) 2023-2024 Quivr Technologies Inc.
+
+With regard to the Quivr Software:
+
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have agreed to,
+and are in compliance with, the Quivr Subscription Terms of Service, available
+at https://quivr.com/pricing (the “Enterprise Terms”), or other
+agreement governing the use of the Software, as agreed by you and Quivr,
+and otherwise have a valid Quivr Enterprise license for the
+correct number of user seats. Subject to the foregoing sentence, you are free to
+modify this Software and publish patches to the Software. You agree that Quivr
+and/or its licensors (as applicable) retain all right, title and interest in and
+to all such modifications and/or patches, and all such modifications and/or
+patches may only be used, copied, modified, displayed, distributed, or otherwise
+exploited with a valid Quivr Enterprise license for the correct
+number of user seats. Notwithstanding the foregoing, you may copy and modify
+the Software for development and testing purposes, without requiring a
+subscription. You agree that Quivr and/or its licensors (as applicable) retain
+all right, title and interest in and to all such modifications. You are not
+granted any other rights beyond what is expressly stated herein. Subject to the
+foregoing, it is forbidden to copy, merge, publish, distribute, sublicense,
+and/or sell the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For all third party components incorporated into the Quivr Software, those
+components are licensed under the original license provided by the owner of the
+applicable component.


### PR DESCRIPTION
This pull request updates the license to include enterprise features. The license now specifies that certain folders or files within the distribution may be subject to different license terms and conditions, which will be specified in a separate LICENSE file or within the file itself. Additionally, a new Quivr Enterprise license has been added, which restricts the use of the software to production environments only if the user has a valid Quivr Enterprise license for the correct number of user seats. The license also clarifies that modifications and patches to the software can only be used with a valid Quivr Enterprise license. Finally, the license includes a disclaimer of warranties and limitations of liability.