### PR TITLE
feat: introducing Ollama embeddings properties.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ OPENAI_API_KEY=CHANGE_ME
 
 # LOCAL
 # OLLAMA_API_BASE_URL=http://host.docker.internal:11434 # Uncomment to activate ollama. This is the local url for the ollama api
+# OLLAMA_EMBEDDINGS_MODEL=
+# OLLAMA_EMBEDDINGS_DOC_INSTRUCT=
+# OLLAMA_EMBEDDINGS_QUERY_INSTRUCT=
 
 ########
 # FRONTEND

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -112,6 +112,9 @@ class BrainSettings(BaseSettings):
     resend_api_key: str = "null"
     resend_email_address: str = "brain@mail.quivr.app"
     ollama_api_base_url: str = None
+    ollama_embeddings_model: str = None,
+    ollama_embeddings_doc_instruct: str = None,
+    ollama_embeddings_query_instruct: str = None,
     langfuse_public_key: str = None
     langfuse_secret_key: str = None
     pg_database_url: str = None
@@ -161,6 +164,9 @@ def get_embeddings():
     if settings.ollama_api_base_url:
         embeddings = OllamaEmbeddings(
             base_url=settings.ollama_api_base_url,
+            model=settings.ollama_embeddings_model,
+            embed_instruction=settings.ollama_embeddings_doc_instruct,
+            query_instruction=settings.ollama_embeddings_query_instruct,
         )  # pyright: ignore reportPrivateUsage=none
     else:
         embeddings = OpenAIEmbeddings()  # pyright: ignore reportPrivateUsage=none

--- a/backend/modules/brain/rags/quivr_rag.py
+++ b/backend/modules/brain/rags/quivr_rag.py
@@ -12,7 +12,6 @@ from langchain.retrievers.document_compressors import FlashrankRerank
 from langchain.schema import format_document
 from langchain_cohere import CohereRerank
 from langchain_community.chat_models import ChatLiteLLM
-from langchain_community.embeddings import OllamaEmbeddings
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate, PromptTemplate
 from langchain_core.pydantic_v1 import BaseModel as BaseModelV1
@@ -21,7 +20,7 @@ from langchain_core.runnables import RunnableLambda, RunnablePassthrough
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from logger import get_logger
 from models import BrainSettings  # Importing settings related to the 'brain'
-from models.settings import get_supabase_client
+from models.settings import get_supabase_client, get_embeddings
 from modules.brain.service.brain_service import BrainService
 from modules.chat.service.chat_service import ChatService
 from modules.knowledge.repository.knowledges import Knowledges
@@ -153,9 +152,7 @@ class QuivrRAG(BaseModel):
     @property
     def embeddings(self):
         if self.brain_settings.ollama_api_base_url:
-            return OllamaEmbeddings(
-                base_url=self.brain_settings.ollama_api_base_url
-            )  # pyright: ignore reportPrivateUsage=none
+            return get_embeddings()
         else:
             return OpenAIEmbeddings()
 

--- a/backend/modules/chat/controller/chat_routes.py
+++ b/backend/modules/chat/controller/chat_routes.py
@@ -3,11 +3,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
-from langchain_community.embeddings import OllamaEmbeddings
 from langchain_openai import OpenAIEmbeddings
 from logger import get_logger
 from middlewares.auth import AuthBearer, get_current_user
-from models.settings import BrainSettings, get_supabase_client
+from models.settings import BrainSettings, get_supabase_client, get_embeddings
 from modules.brain.service.brain_service import BrainService
 from modules.chat.controller.chat.brainful_chat import BrainfulChat
 from modules.chat.dto.chats import ChatItem, ChatQuestion
@@ -40,9 +39,7 @@ def init_vector_store(user_id: UUID) -> CustomSupabaseVectorStore:
     supabase_client = get_supabase_client()
     embeddings = None
     if brain_settings.ollama_api_base_url:
-        embeddings = OllamaEmbeddings(
-            base_url=brain_settings.ollama_api_base_url
-        )  # pyright: ignore reportPrivateUsage=none
+        embeddings = get_embeddings()
     else:
         embeddings = OpenAIEmbeddings()
     vector_store = CustomSupabaseVectorStore(

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -48,6 +48,9 @@ You can find the installation video [here](https://www.youtube.com/watch?v=cXBa6
   > OLLAMA_API_BASE_URL
   > Run the following command to start Ollama: `ollama run llama2`
   > You can find more information about Ollama [here](https://ollama.ai/).
+  > Also you need to rename `backend/supabase/migrations/local_20240107152745_ollama.sql` removing `local_` prefix.
+  > You either need to rename it before starting supabase or run supabase migration after renaming.
+  > Check `.env.example` comments regarding choosing another embeddings model in Ollama
 
 - **Step 4**: Launch the project
 


### PR DESCRIPTION
# Description

Ollama embeddings should be properly configured via these props.
Now only base_url is passed to `OllamaEmbeddings`. It causes the following issues:

- it tries to pick default llama2, but users might not have it installed like #2056 #2595
- if they have `llama2` it yields unreasonably large 4k vectors (compare with 1.5k OpeanAI's)
- these embeds somewhat ok, but might not be what users really need. see https://github.com/ollama/ollama/issues/1624#issuecomment-1879695024 https://github.com/ggerganov/llama.cpp/issues/899
- it also passed default query and document instructions, which might be redundant. 

This change let users to configure embeddings models which is hosted in Ollama. 

## Checklist before requesting a review

Please delete options that are not relevant.

- [v] My code follows the style guidelines of this project
- [v] I have performed a self-review of my code
- [-] I have commented hard-to-understand areas
- [-] I have ideally added tests that prove my fix is effective or that my feature works
- [-] New and existing unit tests pass locally with my changes
- [-] Any dependent changes have been merged

## Screenshots (if appropriate):
