### PR TITLE
chore: Configure Redis priority queues and task routes for Celery

### DIFF
--- a/backend/celery_config.py
+++ b/backend/celery_config.py
@@ -37,6 +37,23 @@ elif CELERY_BROKER_URL.startswith("redis"):
         worker_prefetch_multiplier=2,
         task_serializer="json",
     )
+
+    # Configure Redis priority queues
+    celery.conf.broker_transport_options = {
+        "queue_order_strategy": "priority",
+        "priority_steps": list(range(10)),  # 0-9 priority levels
+        "sep": ":",
+    }
+
+    # Define task routes for priorities
+    celery.conf.task_routes = {
+        "process_file_and_notify": {
+            "queue": "celery",
+            "priority": 9,
+        },  # Highest priority
+        "process_crawl_and_notify": {"queue": "celery", "priority": 8},
+        "*": {"queue": "celery", "priority": 5},  # Default priority for other tasks
+    }
 else:
     raise ValueError(f"Unsupported broker URL: {CELERY_BROKER_URL}")
 


### PR DESCRIPTION
This commit configures Redis priority queues and task routes for Celery. It sets up the queue order strategy as "priority" and defines 10 priority levels (0-9). The task routes are also defined, with "process_file_and_notify" having the highest priority (9), "process_crawl_and_notify" having priority 8, and all other tasks having a default priority of 5.

Note: This commit message does not include any issue references, tags, or author names.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
