### PR TITLE
fix: asyncpg pooling config fix

### DIFF
--- a/backend/api/quivr_api/modules/chat/service/chat_service.py
+++ b/backend/api/quivr_api/modules/chat/service/chat_service.py
@@ -3,6 +3,7 @@ from typing import List
 from uuid import UUID
 
 from fastapi import HTTPException
+
 from quivr_api.logger import get_logger
 from quivr_api.modules.brain.entity.brain_entity import Brain
 from quivr_api.modules.brain.service.brain_service import BrainService
@@ -52,7 +53,7 @@ class ChatService(BaseService[ChatRepository]):
         return inserted_chat
 
     def get_follow_up_question(
-        self, brain_id: UUID = None, question: str = None
+        self, brain_id: UUID | None = None, question: str = None
     ) -> [str]:
         follow_up = [
             "Summarize the conversation",


### PR DESCRIPTION
# Description

closes #2782.

Changes `sqlalchemy` connection pooling config : 

- **pool_pre_ping=True** : pessimistic disconnect handling. 

> - It is critical to note that the pre-ping approach does not accommodate **for connections dropped in the middle of transactions or other SQL operations** ! But this should only happen if we lose the database either due to network of DB server restart. 

- **pool_size=10**,  with no db side pooling for now, if 6 uvicorn process workers  are spawned (or 6 instances of the backed) we have a pool of 60 processes connecting to the database.
- **pool_recycle=1800** :  Recycles the pool every 30min

Added additional session config : 
 - expire_on_commit=False,  When True, all instances will be fully expired after each commit, so that all attribute/object access subsequent to a completed transaction will load from the most recent database state.
 - autoflush=False, query operations will issue a Session.flush() call to this Session before proceeding. We are calling  `session.commit` (which flushes) on each repository method so ne need to reflush on subsequent access