### PR TITLE
chore: Add release-please-core workflow and configuration files

### DIFF
--- a/.github/workflows/release-please-core.yml
+++ b/.github/workflows/release-please-core.yml
@@ -1,0 +1,45 @@
+name: release-please-core
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch all history for tags and releases
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          export PATH="$HOME/.local/bin:$PATH"
+          poetry --version
+
+      - name: Configure Poetry
+        run: |
+          poetry config virtualenvs.in-project true
+          cd backend/core
+          poetry install
+
+      - name: Run release-please
+        uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: manifest
+          manifest-file: release-please-config.json
+          path: backend/core
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,13 @@
+{
+    "packages": {
+        "backend/core": {
+            "release-type": "python",
+            "package-name": "core",
+            "bump-patch-for-minor-pre-major": true,
+            "changelog-notes-type": "github",
+            "include-v-in-tag": false,
+            "tag-separator": "-",
+            "component": "core"
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds the release-please-core workflow and configuration files. The release-please workflow is triggered on push to the main branch and on manual workflow dispatch. It sets up Python, installs Poetry, configures Poetry, and runs release-please for the backend/core package. The release-please configuration file specifies the release type, package name, bump patch for minor pre-major, changelog notes type, include v in tag, tag separator, and component.