### PR TITLE
fix(pyproject): fixed to quivr github

### DIFF
--- a/backend/core/pyproject.toml
+++ b/backend/core/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.2"
 description = "Quivr core RAG package"
 authors = []
 readme = "README.md"
-repository = "https://github.com/langchain-ai/langchain"
+repository = "https://github.com/QuivrHQ/quivr"
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
This pull request updates the repository URL in the pyproject.toml file from "https://github.com/langchain-ai/langchain" to "https://github.com/QuivrHQ/quivr".