### PR TITLE
feat: add integration and integration link to Sources class

### DIFF
--- a/backend/api/quivr_api/modules/chat/dto/chats.py
+++ b/backend/api/quivr_api/modules/chat/dto/chats.py
@@ -34,6 +34,8 @@ class Sources(BaseModel):
     type: str
     original_file_name: str
     citation: str
+    integration: Optional[str] = None
+    integration_link: Optional[str] = None
 
 
 class ChatItemType(Enum):

--- a/backend/api/quivr_api/modules/rag_service/utils.py
+++ b/backend/api/quivr_api/modules/rag_service/utils.py
@@ -87,6 +87,8 @@ def generate_source(
                     source_url=source_url,
                     original_file_name=name,
                     citation=doc.page_content,
+                    integration=doc.metadata["integration"],
+                    integration_link=doc.metadata["integration_link"],
                 )
             )
     else:


### PR DESCRIPTION
The Sources class in `chats.py` now includes optional fields for integration and integration link. This allows for better tracking and integration of external sources in the chat module.

