### PR TITLE
feat: Add environment variable for showing tokens in frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -84,6 +84,8 @@ ENV HOSTNAME "0.0.0.0"
 
 ARG NEXT_PUBLIC_AUTH_MODES
 ENV NEXT_PUBLIC_AUTH_MODES=$NEXT_PUBLIC_AUTH_MODES
+ARG NEXT_PUBLIC_SHOW_TOKENS
+ENV NEXT_PUBLIC_SHOW_TOKENS=$NEXT_PUBLIC_SHOW_TOKENS
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output


### PR DESCRIPTION
The Dockerfile was modified to include a new environment variable `NEXT_PUBLIC_SHOW_TOKENS` which controls whether tokens should be shown in the frontend. This change was made to enhance the user experience and provide more flexibility in managing token visibility.

Fix ENT-54
