### PR TITLE
chore: update next.config.js with PostHog domains

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -71,6 +71,8 @@ const ContentSecurityPolicy = {
     "https://cdn.growthbook.io",
     "https://vitals.vercel-insights.com/v1/vitals",
     "https://us.posthog.com",
+    "*.posthog.com",
+    "https://us.i.posthog.com"
   ],
   "img-src": [
     "'self'",


### PR DESCRIPTION
This commit adds two PostHog domains to the Content Security Policy in the next.config.js file. The domains are "*.posthog.com" and "https://us.i.posthog.com".

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
