### PR TITLE
feat: update SyncsUser status field to be optional

### DIFF
--- a/backend/api/quivr_api/modules/sync/entity/sync_models.py
+++ b/backend/api/quivr_api/modules/sync/entity/sync_models.py
@@ -59,7 +59,7 @@ class SyncsUser(BaseModel):
     credentials: dict
     state: dict
     additional_data: dict
-    status: str
+    status: Optional[str] = None
 
 
 class SyncsActive(BaseModel):


### PR DESCRIPTION
The SyncsUser model in sync_models.py now has an optional status field. This change allows for more flexibility in managing user synchronization status.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
