### PR TITLE
feat: Update knowledge status and send notification on task success

### DIFF
--- a/backend/worker/quivr_worker/celery_monitor.py
+++ b/backend/worker/quivr_worker/celery_monitor.py
@@ -88,30 +88,30 @@ async def handler_loop():
                         f"task {event.task_id} process_file_task . Updating knowledge {event.knowledge_id} status to Error"
                     )
 
-                if event.status == TaskStatus.SUCCESS:
-                    logger.info(
-                        f"task {event.task_id} process_file_task succeeded. Sending notification {event.notification_id}"
-                    )
-                    notification_service.update_notification_by_id(
-                        event.notification_id,
-                        NotificationUpdatableProperties(
-                            status=NotificationsStatusEnum.SUCCESS,
-                            description=(
-                                "Your file has been properly uploaded!"
-                                if event.task_name == TaskIdentifier.PROCESS_FILE_TASK
-                                else "Your URL has been properly crawled!"
-                            ),
+            if event.status == TaskStatus.SUCCESS:
+                logger.info(
+                    f"task {event.task_id} process_file_task succeeded. Sending notification {event.notification_id}"
+                )
+                notification_service.update_notification_by_id(
+                    event.notification_id,
+                    NotificationUpdatableProperties(
+                        status=NotificationsStatusEnum.SUCCESS,
+                        description=(
+                            "Your file has been properly uploaded!"
+                            if event.task_name == TaskIdentifier.PROCESS_FILE_TASK
+                            else "Your URL has been properly crawled!"
                         ),
+                    ),
+                )
+                if event.knowledge_id:
+                    await knowledge_service.update_status_knowledge(
+                        knowledge_id=event.knowledge_id,
+                        status=KnowledgeStatus.UPLOADED,
+                        brain_id=event.brain_id,
                     )
-                    if event.knowledge_id:
-                        await knowledge_service.update_status_knowledge(
-                            knowledge_id=event.knowledge_id,
-                            status=KnowledgeStatus.UPLOADED,
-                            brain_id=event.brain_id,
-                        )
-                    logger.info(
-                        f"task {event.task_id} process_file_task failed. Updating knowledge {event.knowledge_id} to UPLOADED"
-                    )
+                logger.info(
+                    f"task {event.task_id} process_file_task failed. Updating knowledge {event.knowledge_id} to UPLOADED"
+                )
 
         except Exception as e:
             logger.error(f"Excpetion occured handling event {event}: {e}")


### PR DESCRIPTION
This commit updates the code in `celery_monitor.py` to handle task success events. When a task with a status of `SUCCESS` is received, it sends a notification with a success status and a corresponding description. Additionally, if the event has a `knowledge_id`, it updates the knowledge status to `UPLOADED`. This change improves the handling of task success events and ensures that notifications and knowledge statuses are properly updated.

Note: This commit message follows the established convention of starting with a verb in the imperative form, followed by a brief description of the changes.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
