### PR TITLE
feat: Update Content Security Policy for PostHog

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -105,9 +105,9 @@ const ContentSecurityPolicy = {
     "https://*.vercel.app",
     "https://www.google-analytics.com/",
     "https://js.stripe.com",
-    "https://us.posthog.com",
+    "https://*.posthog.com",
   ],
-  "frame-src": ["https://js.stripe.com", "https://us.posthog.com"],
+  "frame-src": ["https://js.stripe.com", "https://*.posthog.com"],
   "frame-ancestors": ["'none'"],
   "style-src": [
     "'unsafe-inline'",


### PR DESCRIPTION
The `next.config.js` file has been modified to update the Content Security Policy (CSP) for PostHog. The CSP now allows requests to any subdomain of `posthog.com` for both `script-src` and `frame-src`. This change ensures that the frontend application can properly communicate with PostHog services.

Co-authored-by: Stan Girard <girard.stanislas@gmail.com>

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
