### PR TITLE
chore(examples): add basic RAG workflow configuration

### DIFF
--- a/examples/chatbot/basic_rag_workflow.yaml
+++ b/examples/chatbot/basic_rag_workflow.yaml
@@ -1,0 +1,41 @@
+workflow_config:
+  name: "standard RAG"
+  nodes:
+    - name: "START"
+      edges: ["filter_history"]
+
+    - name: "filter_history"
+      edges: ["rewrite"]
+
+    - name: "rewrite"
+      edges: ["retrieve"]
+
+    - name: "retrieve"
+      edges: ["generate_rag"]
+
+    - name: "generate_rag" # the name of the last node, from which we want to stream the answer to the user
+      edges: ["END"]
+
+# Maximum number of previous conversation iterations
+# to include in the context of the answer
+max_history: 10
+
+# Reranker configuration
+# reranker_config:
+#   # The reranker supplier to use
+#   supplier: "cohere"
+
+#   # The model to use for the reranker for the given supplier
+#   model: "rerank-multilingual-v3.0"
+
+#   # Number of chunks returned by the reranker
+#   top_n: 5
+
+# Configuration for the LLM
+llm_config:
+
+  # maximum number of tokens passed to the LLM to generate the answer
+  max_output_tokens: 4000
+
+  # temperature for the LLM
+  temperature: 0.7

--- a/examples/chatbot/main.py
+++ b/examples/chatbot/main.py
@@ -1,8 +1,8 @@
-import os
 import tempfile
 
 import chainlit as cl
 from quivr_core import Brain
+from quivr_core.rag.entities.config import RetrievalConfig
 
 
 @cl.on_chat_start
@@ -27,7 +27,7 @@ async def on_chat_start():
         text = f.read()
 
     with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".txt", delete=False
+        mode="w", suffix=file.name, delete=False
     ) as temp_file:
         temp_file.write(text)
         temp_file.flush()
@@ -48,6 +48,8 @@ async def on_chat_start():
 @cl.on_message
 async def main(message: cl.Message):
     brain = cl.user_session.get("brain")  # type: Brain
+    path_config = "basic_rag_workflow.yaml"
+    retrieval_config = RetrievalConfig.from_yaml(path_config)
 
     if brain is None:
         await cl.Message(content="Please upload a file first.").send()
@@ -57,11 +59,25 @@ async def main(message: cl.Message):
     msg = cl.Message(content="", elements=[])
     await msg.send()
 
+    saved_sources = set()
+    saved_sources_complete = []
+    elements = []
+
     # Use the ask_stream method for streaming responses
-    async for chunk in brain.ask_streaming(message.content):
+    async for chunk in brain.ask_streaming(message.content, retrieval_config=retrieval_config):
         await msg.stream_token(chunk.answer)
         for source in chunk.metadata.sources:
-            print(source.metadata)
-            msg.elements.append(cl.Text(name=source.metadata['original_file_name'], content="source", display="inline"))
+            if source.page_content not in saved_sources:
+                saved_sources.add(source.page_content)
+                saved_sources_complete.append(source)
+                print(source)
+                elements.append(cl.Text(name=source.metadata["original_file_name"], content=source.page_content, display="side"))
 
+    
     await msg.send()
+    sources = ""
+    for source in saved_sources_complete:
+        sources += f"- {source.metadata['original_file_name']}\n"
+    msg.elements = elements
+    msg.content = msg.content + f"\n\nSources:\n{sources}"
+    await msg.update()


### PR DESCRIPTION
- Added a new file `basic_rag_workflow.yaml` to the `examples/chatbot` directory.
- Configured a standard RAG workflow with multiple nodes and edges.
- Set the maximum number of previous conversation iterations to include in the answer context.
- Added configuration for the LLM (Language Model) with maximum output tokens and temperature.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
