### PR TITLE
fix: fixing errors arising when the user input contains no tasks

### DIFF
--- a/core/quivr_core/rag/quivr_rag_langgraph.py
+++ b/core/quivr_core/rag/quivr_rag_langgraph.py
@@ -71,11 +71,11 @@ class SplittedInput(BaseModel):
 class TasksCompletion(BaseModel):
     is_task_completable_reasoning: Optional[str] = Field(
         default=None,
-        description="The reasoning that leads to identifying whether the user task or question can be completed using the provided context and chat history.",
+        description="The reasoning that leads to identifying whether the user task or question can be completed using the provided context and chat history BEFORE any tool is used.",
     )
 
     is_task_completable: bool = Field(
-        description="Whether the user task or question can be completed using the provided context and chat history.",
+        description="Whether the user task or question can be completed using the provided context and chat history BEFORE any tool is used.",
     )
 
     tool_reasoning: Optional[str] = Field(
@@ -667,7 +667,7 @@ class QuivrQARAGLangGraph:
         MAX_ITERATIONS = 3
 
         tasks = state["tasks"]
-        if not tasks.has_tasks():
+        if not tasks or not tasks.has_tasks():
             return {**state}
 
         k = self.retrieval_config.k
@@ -1031,7 +1031,7 @@ class QuivrQARAGLangGraph:
         return {
             "context": combine_documents(docs) if docs else "None",
             "question": user_question,
-            "rephrased_task": state["tasks"].definitions,
+            "rephrased_task": state["tasks"].definitions if state["tasks"] else "None",
             "custom_instructions": prompt if prompt else "None",
             "files": files if files else "None",
             "chat_history": state["chat_history"].to_list(),


### PR DESCRIPTION
We fix an error arising when the user input contains no tasks, but only system instructions

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
