### PR TITLE
feat: returning a description of each workflow node

### DIFF
--- a/core/quivr_core/rag/entities/config.py
+++ b/core/quivr_core/rag/entities/config.py
@@ -398,6 +398,7 @@ class ConditionalEdgeConfig(QuivrBaseConfig):
 
 class NodeConfig(QuivrBaseConfig):
     name: str
+    description: str | None = None
     edges: List[str] | None = None
     conditional_edge: ConditionalEdgeConfig | None = None
     tools: List[Dict[str, Any]] | None = None

--- a/core/quivr_core/rag/entities/models.py
+++ b/core/quivr_core/rag/entities/models.py
@@ -76,6 +76,7 @@ class RAGResponseMetadata(BaseModel):
     followup_questions: list[str] = Field(default_factory=list)
     sources: list[Any] = Field(default_factory=list)
     metadata_model: ChatLLMMetadata | None = None
+    workflow_step: str | None = None
 
 
 class ParsedRAGResponse(BaseModel):

--- a/core/quivr_core/rag/quivr_rag_langgraph.py
+++ b/core/quivr_core/rag/quivr_rag_langgraph.py
@@ -13,7 +13,6 @@ from typing import (
     TypedDict,
 )
 from uuid import UUID, uuid4
-
 import openai
 from langchain.retrievers import ContextualCompressionRetriever
 from langchain_cohere import CohereRerank
@@ -1009,8 +1008,6 @@ class QuivrQARAGLangGraph:
                 if node.name == name:
                     if node.description:
                         return node.description
-                    elif node.label:
-                        return node.label
                     else:
                         return node.name
         return ""


### PR DESCRIPTION
# Description

By returning a description of each node executed by a (LangGraph) workflow we can show it to the user and thus inform him about the status of the task execution