### PR TITLE
feat: limit tokenizers cache size

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "langchain-mistralai>=0.2.3",
     "fasttext-langdetect>=1.0.5",
     "langfuse>=2.57.0",
+    "pympler>=1.1",
 ]
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/core/requirements-dev.lock
+++ b/core/requirements-dev.lock
@@ -296,6 +296,8 @@ pyflakes==3.2.0
 pygments==2.18.0
     # via ipython
     # via rich
+pympler==1.1
+    # via quivr-core
 pytest==8.3.3
     # via pytest-asyncio
     # via pytest-benchmark

--- a/core/requirements.lock
+++ b/core/requirements.lock
@@ -214,6 +214,8 @@ pydantic-settings==2.6.1
     # via langchain-community
 pygments==2.18.0
     # via rich
+pympler==1.1
+    # via quivr-core
 python-dateutil==2.8.2
     # via pandas
 python-dotenv==1.0.1


### PR DESCRIPTION
We limit the number of preloaded tokenizers to 3 and the maximum size to 50 MB