### PR TITLE
feat: remove pympler dependency and add better way to calculate size of tokenizer cache

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "langchain-mistralai>=0.2.3",
     "fasttext-langdetect>=1.0.5",
     "langfuse>=2.57.0",
-    "pympler>=1.1",
 ]
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/core/quivr_core/llm/llm_endpoint.py
+++ b/core/quivr_core/llm/llm_endpoint.py
@@ -25,6 +25,7 @@ class LLMTokenizer:
     _max_cache_size_mb: int = 50
     _max_cache_count: int = 5  # Default maximum number of cached tokenizers
     _current_cache_size: int = 0
+    _default_size: int = 5 * 1024 * 1024
 
     def __init__(self, tokenizer_hub: str | None, fallback_tokenizer: str):
         self.tokenizer_hub = tokenizer_hub
@@ -66,7 +67,7 @@ class LLMTokenizer:
         if not hasattr(self.tokenizer, "vocab_files_names") or not hasattr(
             self.tokenizer, "init_kwargs"
         ):
-            return 5 * 1024 * 1024
+            return self._default_size
 
         total_size = 0
 
@@ -80,7 +81,7 @@ class LLMTokenizer:
                 except (OSError, FileNotFoundError):
                     logger.debug(f"Could not access tokenizer file: {file_path}")
 
-        return total_size if total_size > 0 else 5 * 1024 * 1024
+        return total_size if total_size > 0 else self._default_size
 
     @classmethod
     def load(cls, tokenizer_hub: str, fallback_tokenizer: str):

--- a/core/quivr_core/llm/llm_endpoint.py
+++ b/core/quivr_core/llm/llm_endpoint.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Union, Any
+from typing import Union
 from urllib.parse import parse_qs, urlparse
 
 import tiktoken
@@ -10,7 +10,6 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
 from pydantic import SecretStr
 import time
-import sys
 
 from quivr_core.brain.info import LLMInfo
 from quivr_core.rag.entities.config import DefaultModelSuppliers, LLMEndpointConfig
@@ -19,37 +18,12 @@ from quivr_core.rag.utils import model_supports_function_calling
 logger = logging.getLogger("quivr_core")
 
 
-def get_size(obj: Any, seen: set | None = None) -> int:
-    """Calculate approximate size of object in bytes recursively"""
-    if seen is None:
-        seen = set()
-
-    # Skip if object already seen or is None
-    obj_id = id(obj)
-    if obj_id in seen or obj is None:
-        return 0
-    seen.add(obj_id)
-
-    size = sys.getsizeof(obj)
-
-    if isinstance(obj, dict):
-        size += sum(get_size(k, seen) + get_size(v, seen) for k, v in obj.items())
-    elif isinstance(obj, (list, tuple, set)):
-        size += sum(get_size(item, seen) for item in obj)
-    elif hasattr(obj, "__dict__"):
-        size += get_size(obj.__dict__, seen)
-    elif hasattr(obj, "__slots__"):
-        size += sum(get_size(getattr(obj, slot, None), seen) for slot in obj.__slots__)
-
-    return size
-
-
 class LLMTokenizer:
     _cache: dict[
         int, tuple["LLMTokenizer", int, float]
     ] = {}  # {hash: (tokenizer, size_bytes, last_access_time)}
     _max_cache_size_mb: int = 50
-    _max_cache_count: int = 3  # Default maximum number of cached tokenizers
+    _max_cache_count: int = 5  # Default maximum number of cached tokenizers
     _current_cache_size: int = 0
 
     def __init__(self, tokenizer_hub: str | None, fallback_tokenizer: str):
@@ -84,7 +58,29 @@ class LLMTokenizer:
             self.tokenizer = tiktoken.get_encoding(self.fallback_tokenizer)
 
         # More accurate size estimation
-        self._size_bytes = get_size(self.tokenizer)
+        self._size_bytes = self._calculate_tokenizer_size()
+
+    def _calculate_tokenizer_size(self) -> int:
+        """Calculate size of tokenizer by summing the sizes of its vocabulary and model files"""
+        # By default, return a size of 5 MB
+        if not hasattr(self.tokenizer, "vocab_files_names") or not hasattr(
+            self.tokenizer, "init_kwargs"
+        ):
+            return 5 * 1024 * 1024
+
+        total_size = 0
+
+        # Get the file keys from vocab_files_names
+        file_keys = self.tokenizer.vocab_files_names.keys()
+        # Look up these files in init_kwargs
+        for key in file_keys:
+            if file_path := self.tokenizer.init_kwargs.get(key):
+                try:
+                    total_size += os.path.getsize(file_path)
+                except (OSError, FileNotFoundError):
+                    logger.debug(f"Could not access tokenizer file: {file_path}")
+
+        return total_size if total_size > 0 else 5 * 1024 * 1024
 
     @classmethod
     def load(cls, tokenizer_hub: str, fallback_tokenizer: str):

--- a/core/requirements-dev.lock
+++ b/core/requirements-dev.lock
@@ -296,8 +296,6 @@ pyflakes==3.2.0
 pygments==2.18.0
     # via ipython
     # via rich
-pympler==1.1
-    # via quivr-core
 pytest==8.3.3
     # via pytest-asyncio
     # via pytest-benchmark

--- a/core/requirements.lock
+++ b/core/requirements.lock
@@ -214,8 +214,6 @@ pydantic-settings==2.6.1
     # via langchain-community
 pygments==2.18.0
     # via rich
-pympler==1.1
-    # via quivr-core
 python-dateutil==2.8.2
     # via pandas
 python-dotenv==1.0.1


### PR DESCRIPTION
We now compute the size of the tokenizer cache using the disk file size of the different tokenizer files