### PR TITLE
feat: cache llm endpoint

### DIFF
--- a/core/quivr_core/rag/entities/config.py
+++ b/core/quivr_core/rag/entities/config.py
@@ -303,6 +303,23 @@ class LLMEndpointConfig(QuivrBaseConfig):
 
     _FALLBACK_TOKENIZER = "cl100k_base"
 
+    def __hash__(self):
+        return hash(
+            (
+                self.supplier,
+                self.model,
+                self.tokenizer_hub,
+                self.llm_base_url,
+                self.env_variable_name,
+                self.llm_api_key,
+                self.max_context_tokens,
+                self.max_output_tokens,
+                self.temperature,
+                self.streaming,
+                repr(self.prompt) if self.prompt is not None else None,
+            )
+        )
+
     @property
     def fallback_tokenizer(self) -> str:
         return self._FALLBACK_TOKENIZER


### PR DESCRIPTION
# Description

- Avoid recreating llm in from_config call. We are recreating an http connection
- Fix liniting for langchain, their attributes are all over the place in langchain .... 