### PR TITLE
fix: resolve Python Logger warnings

### DIFF
--- a/core/quivr_core/processor/registry.py
+++ b/core/quivr_core/processor/registry.py
@@ -173,7 +173,7 @@ def get_processor_class(file_extension: FileExtension | str) -> Type[ProcessorBa
                 register_processor(file_extension, _import_class(proc_entry.cls_mod))
                 break
             except ImportError:
-                logger.warn(
+                logger.warning(
                     f"{proc_entry.err}. Falling to the next available processor for {file_extension}"
                 )
         if len(entries) == 0 and file_extension not in registry:


### PR DESCRIPTION
# Description
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Checklist before requesting a review

Please delete options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
