### PR TITLE
fix(docs): Replace broken Discord badge with shields.io version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <img src="./logo.png" alt="Quivr-logo" width="31%"  style="border-radius: 50%; padding-bottom: 20px"/>
 </div>
 
-[![Discord Follow](https://dcbadge.vercel.app/api/server/HUpRgp2HG8?style=flat)](https://discord.gg/HUpRgp2HG8)
+[![Discord Follow](https://img.shields.io/badge/Discord-Follow-blue?logo=discord&style=social)](https://discord.gg/HUpRgp2HG8)
 [![GitHub Repo stars](https://img.shields.io/github/stars/quivrhq/quivr?style=social)](https://github.com/quivrhq/quivr)
 [![Twitter Follow](https://img.shields.io/twitter/follow/StanGirard?style=social)](https://twitter.com/_StanGirard)
 


### PR DESCRIPTION
The previous Discord badge sourced from `dcbadge.vercel.app` was unreliable and frequently failed to render. This update replaces it with a `shields.io` badge that provides consistent styling and improved visibility.

## Motivation
Enhance the visual clarity and professional appearance of the README by ensuring all badges load reliably.

## Changes
- Updated the Discord badge link in `README.md`
- Switched from `dcbadge.vercel.app` to `shields.io` with `style=social` for better alignment with other badges (e.g., Twitter)

## Checklist ✅
- [x] My change is limited to documentation only
- [x] I have verified the badge renders correctly
- [x] No functional or configuration files were touched

## Related
No GitHub Issue associated. Minor documentation update.

---

Attached below is the screenshot showing the previous broken badge for reference.

<img width="388" height="51" alt="Screenshot 2025-07-12 222256" src="https://github.com/user-attachments/assets/16f80e6d-53dc-4241-beaf-5f94c6750b2e" />

