### PR TITLE
feat: add Avian as an LLM provider

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,12 +14,10 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv venv
+    - sed -i "s|file:///\${PROJECT_ROOT}/\.\./core|file://$PWD/core|g" docs/requirements.lock
     - cd docs && UV_INDEX_STRATEGY=unsafe-first-match uv pip install -r requirements.lock
     - cd docs/ && ls -la && NO_COLOR=1 ../.venv/bin/mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.yml
 
-  
-
 
 mkdocs:
-  configuration: backend/docs/mkdocs.yml
-
+  configuration: docs/mkdocs.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv venv
-    - .venv/bin/python -m pip install ./core
+    - uv pip install ./core
     - grep -v '^quivr-core' docs/requirements.lock > /tmp/requirements-filtered.lock && cd docs && UV_INDEX_STRATEGY=unsafe-first-match uv pip install -r /tmp/requirements-filtered.lock
     - cd docs/ && ls -la && NO_COLOR=1 ../.venv/bin/mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.yml
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,8 +14,8 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv venv
-    - sed -i "s|file:///\${PROJECT_ROOT}/\.\./core|file://$PWD/core|g" docs/requirements.lock
-    - cd docs && UV_INDEX_STRATEGY=unsafe-first-match uv pip install -r requirements.lock
+    - .venv/bin/python -m pip install ./core
+    - grep -v '^quivr-core' docs/requirements.lock > /tmp/requirements-filtered.lock && cd docs && UV_INDEX_STRATEGY=unsafe-first-match uv pip install -r /tmp/requirements-filtered.lock
     - cd docs/ && ls -la && NO_COLOR=1 ../.venv/bin/mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.yml
 
 

--- a/core/quivr_core/llm/llm_endpoint.py
+++ b/core/quivr_core/llm/llm_endpoint.py
@@ -291,6 +291,16 @@ class LLMEndpoint:
                     max_tokens=config.max_output_tokens,
                     temperature=config.temperature,
                 )
+            elif config.supplier == DefaultModelSuppliers.AVIAN:
+                _llm = ChatOpenAI(
+                    model=config.model,
+                    api_key=SecretStr(config.llm_api_key)
+                    if config.llm_api_key
+                    else None,
+                    base_url=config.llm_base_url or "https://api.avian.io/v1",
+                    max_completion_tokens=config.max_output_tokens,
+                    temperature=config.temperature,
+                )
 
             else:
                 _llm = ChatOpenAI(

--- a/core/quivr_core/rag/entities/config.py
+++ b/core/quivr_core/rag/entities/config.py
@@ -75,6 +75,7 @@ class DefaultModelSuppliers(str, Enum):
     MISTRAL = "mistral"
     GROQ = "groq"
     GEMINI = "gemini"
+    AVIAN = "avian"
 
 
 class LLMConfig(QuivrBaseConfig):
@@ -273,6 +274,24 @@ class LLMModelConfig:
                 max_context_tokens=128000,
                 max_output_tokens=4096,
                 tokenizer_hub="Quivr/gemini-tokenizer",
+            ),
+        },
+        DefaultModelSuppliers.AVIAN: {
+            "deepseek/deepseek-v3.2": LLMConfig(
+                max_context_tokens=164000,
+                max_output_tokens=65000,
+            ),
+            "moonshotai/kimi-k2.5": LLMConfig(
+                max_context_tokens=131000,
+                max_output_tokens=8192,
+            ),
+            "z-ai/glm-5": LLMConfig(
+                max_context_tokens=131000,
+                max_output_tokens=16384,
+            ),
+            "minimax/minimax-m2.5": LLMConfig(
+                max_context_tokens=1000000,
+                max_output_tokens=1000000,
             ),
         },
     }

--- a/core/tests/test_llm_endpoint.py
+++ b/core/tests/test_llm_endpoint.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from langchain_core.language_models import FakeListChatModel
 from pydantic import ValidationError
-from quivr_core.rag.entities.config import LLMEndpointConfig
+from quivr_core.rag.entities.config import DefaultModelSuppliers, LLMEndpointConfig
 from quivr_core.llm import LLMEndpoint
 
 
@@ -46,3 +46,21 @@ def test_llm_endpoint_constructor():
     )
 
     assert not llm_endpoint.supports_func_calling()
+
+
+@pytest.mark.base
+def test_llm_endpoint_avian():
+    from langchain_openai import ChatOpenAI
+
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.AVIAN,
+        model="deepseek/deepseek-v3.2",
+        llm_api_key="test",
+    )
+    llm = LLMEndpoint.from_config(config)
+
+    assert llm.supports_func_calling()
+    assert isinstance(llm._llm, ChatOpenAI)
+    assert llm._llm.openai_api_base == "https://api.avian.io/v1"
+    assert config.max_output_tokens == 65000
+    assert config.max_context_tokens <= 164000

--- a/docs/requirements-dev.lock
+++ b/docs/requirements-dev.lock
@@ -217,7 +217,7 @@ mdit-py-plugins==0.4.1
     # via jupytext
 mdurl==0.1.2
     # via markdown-it-py
-megaparse-sdk==0.1.10
+megaparse-sdk==0.1.11
     # via quivr-core
 mergedeep==1.3.4
     # via mkdocs

--- a/docs/requirements.lock
+++ b/docs/requirements.lock
@@ -217,7 +217,7 @@ mdit-py-plugins==0.4.1
     # via jupytext
 mdurl==0.1.2
     # via markdown-it-py
-megaparse-sdk==0.1.10
+megaparse-sdk==0.1.11
     # via quivr-core
 mergedeep==1.3.4
     # via mkdocs


### PR DESCRIPTION
## Summary
- Add [Avian](https://avian.io) as a supported LLM supplier in quivr-core
- Avian provides an OpenAI-compatible API (chat completions, streaming, function calling) at `https://api.avian.io/v1`
- Uses `ChatOpenAI` from langchain-openai since the API is fully OpenAI-compatible — no new dependencies required

## Models
| Model | Context | Max Output | Input $/1M | Output $/1M |
|-------|---------|------------|------------|-------------|
| `deepseek/deepseek-v3.2` | 164K | 65K | $0.26 | $0.38 |
| `moonshotai/kimi-k2.5` | 131K | 8K | $0.45 | $2.20 |
| `z-ai/glm-5` | 131K | 16K | $0.30 | $2.55 |
| `minimax/minimax-m2.5` | 1M | 1M | $0.30 | $1.10 |

## Changes
- Add `AVIAN` to `DefaultModelSuppliers` enum
- Add Avian model configurations with context/output token limits to `LLMModelConfig`
- Add `AVIAN` supplier handling in `LLMEndpoint.from_config()` (uses `ChatOpenAI` with default base URL `https://api.avian.io/v1`)
- Add unit test for Avian endpoint configuration

## Usage
```python
from quivr_core.rag.entities.config import DefaultModelSuppliers, LLMEndpointConfig
from quivr_core.llm import LLMEndpoint

config = LLMEndpointConfig(
    supplier=DefaultModelSuppliers.AVIAN,
    model="deepseek/deepseek-v3.2",
    llm_api_key="your-avian-api-key",  # or set AVIAN_API_KEY env var
)
llm = LLMEndpoint.from_config(config)
```

## Test plan
- [x] Unit test added: `test_llm_endpoint_avian` verifies correct `ChatOpenAI` instantiation, base URL, and token limits

cc @StanGirard @chloedia