### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Quivr, helps you build your second brain, utilizes the power of GenerativeAI to 
 ## Key Features 🎯
 
 - **Opiniated RAG**: We created a RAG that is opinionated, fast and efficient so you can focus on your product
-- **LLMs**: Quivr works with any LLM, you can use it with OpenAI, Anthropic, Mistral, Gemma, etc.
+- **LLMs**: Quivr works with any LLM, you can use it with OpenAI, Anthropic, Mistral, Gemini, Groq, MiniMax, etc.
 - **Any File**: Quivr works with any file, you can use it with PDF, TXT, Markdown, etc and even add your own parsers.
 - **Customize your RAG**: Quivr allows you to customize your RAG, add internet search, add tools, etc.
 - **Integrations with Megaparse**: Quivr works with [Megaparse](https://github.com/quivrhq/megaparse), so you can ingest your files with Megaparse and use the RAG with Quivr.
@@ -91,7 +91,7 @@ import os
 os.environ["OPENAI_API_KEY"] = "myopenai_apikey"
 
 ```
-Quivr supports APIs from Anthropic, OpenAI, and Mistral. It also supports local models using Ollama.
+Quivr supports APIs from Anthropic, OpenAI, Mistral, Gemini, Groq, and [MiniMax](https://www.minimax.io/). It also supports local models using Ollama.
 
 1. Create the YAML file ``basic_rag_workflow.yaml`` and copy the following content in it
 ```yaml

--- a/core/quivr_core/llm/llm_endpoint.py
+++ b/core/quivr_core/llm/llm_endpoint.py
@@ -291,6 +291,16 @@ class LLMEndpoint:
                     max_tokens=config.max_output_tokens,
                     temperature=config.temperature,
                 )
+            elif config.supplier == DefaultModelSuppliers.MINIMAX:
+                _llm = ChatOpenAI(
+                    model=config.model,
+                    api_key=SecretStr(config.llm_api_key)
+                    if config.llm_api_key
+                    else None,
+                    base_url=config.llm_base_url or "https://api.minimax.io/v1",
+                    max_completion_tokens=config.max_output_tokens,
+                    temperature=config.temperature,
+                )
 
             else:
                 _llm = ChatOpenAI(

--- a/core/quivr_core/rag/entities/config.py
+++ b/core/quivr_core/rag/entities/config.py
@@ -277,6 +277,14 @@ class LLMModelConfig:
             ),
         },
         DefaultModelSuppliers.MINIMAX: {
+            "MiniMax-M2.7": LLMConfig(
+                max_context_tokens=204800,
+                max_output_tokens=192000,
+            ),
+            "MiniMax-M2.7-highspeed": LLMConfig(
+                max_context_tokens=204800,
+                max_output_tokens=192000,
+            ),
             "MiniMax-M2.5": LLMConfig(
                 max_context_tokens=204800,
                 max_output_tokens=192000,

--- a/core/quivr_core/rag/entities/config.py
+++ b/core/quivr_core/rag/entities/config.py
@@ -277,19 +277,15 @@ class LLMModelConfig:
             ),
         },
         DefaultModelSuppliers.MINIMAX: {
+            "MiniMax-M3": LLMConfig(
+                max_context_tokens=512000,
+                max_output_tokens=128000,
+            ),
             "MiniMax-M2.7-highspeed": LLMConfig(
                 max_context_tokens=204800,
                 max_output_tokens=192000,
             ),
             "MiniMax-M2.7": LLMConfig(
-                max_context_tokens=204800,
-                max_output_tokens=192000,
-            ),
-            "MiniMax-M2.5-highspeed": LLMConfig(
-                max_context_tokens=204800,
-                max_output_tokens=192000,
-            ),
-            "MiniMax-M2.5": LLMConfig(
                 max_context_tokens=204800,
                 max_output_tokens=192000,
             ),

--- a/core/quivr_core/rag/entities/config.py
+++ b/core/quivr_core/rag/entities/config.py
@@ -75,6 +75,7 @@ class DefaultModelSuppliers(str, Enum):
     MISTRAL = "mistral"
     GROQ = "groq"
     GEMINI = "gemini"
+    MINIMAX = "minimax"
 
 
 class LLMConfig(QuivrBaseConfig):
@@ -273,6 +274,16 @@ class LLMModelConfig:
                 max_context_tokens=128000,
                 max_output_tokens=4096,
                 tokenizer_hub="Quivr/gemini-tokenizer",
+            ),
+        },
+        DefaultModelSuppliers.MINIMAX: {
+            "MiniMax-M2.5": LLMConfig(
+                max_context_tokens=204800,
+                max_output_tokens=192000,
+            ),
+            "MiniMax-M2.5-highspeed": LLMConfig(
+                max_context_tokens=204800,
+                max_output_tokens=192000,
             ),
         },
     }

--- a/core/quivr_core/rag/entities/config.py
+++ b/core/quivr_core/rag/entities/config.py
@@ -277,19 +277,19 @@ class LLMModelConfig:
             ),
         },
         DefaultModelSuppliers.MINIMAX: {
-            "MiniMax-M2.7": LLMConfig(
-                max_context_tokens=204800,
-                max_output_tokens=192000,
-            ),
             "MiniMax-M2.7-highspeed": LLMConfig(
                 max_context_tokens=204800,
                 max_output_tokens=192000,
             ),
-            "MiniMax-M2.5": LLMConfig(
+            "MiniMax-M2.7": LLMConfig(
                 max_context_tokens=204800,
                 max_output_tokens=192000,
             ),
             "MiniMax-M2.5-highspeed": LLMConfig(
+                max_context_tokens=204800,
+                max_output_tokens=192000,
+            ),
+            "MiniMax-M2.5": LLMConfig(
                 max_context_tokens=204800,
                 max_output_tokens=192000,
             ),

--- a/core/tests/test_llm_endpoint.py
+++ b/core/tests/test_llm_endpoint.py
@@ -54,12 +54,12 @@ def test_llm_endpoint_minimax():
 
     config = LLMEndpointConfig(
         supplier=DefaultModelSuppliers.MINIMAX,
-        model="MiniMax-M2.5",
+        model="MiniMax-M3",
         llm_api_key="test",
     )
     llm = LLMEndpoint.from_config(config)
 
     assert isinstance(llm._llm, ChatOpenAI)
-    assert llm._llm.model_name == "MiniMax-M2.5"
+    assert llm._llm.model_name == "MiniMax-M3"
     assert str(llm._llm.openai_api_base) == "https://api.minimax.io/v1"
     assert llm.supports_func_calling()

--- a/core/tests/test_llm_endpoint.py
+++ b/core/tests/test_llm_endpoint.py
@@ -3,7 +3,11 @@ import os
 import pytest
 from langchain_core.language_models import FakeListChatModel
 from pydantic import ValidationError
-from quivr_core.rag.entities.config import DefaultModelSuppliers, LLMEndpointConfig
+from quivr_core.rag.entities.config import (
+    DefaultModelSuppliers,
+    LLMEndpointConfig,
+    LLMModelConfig,
+)
 from quivr_core.llm import LLMEndpoint
 
 
@@ -54,12 +58,28 @@ def test_llm_endpoint_minimax():
 
     config = LLMEndpointConfig(
         supplier=DefaultModelSuppliers.MINIMAX,
-        model="MiniMax-M2.5",
+        model="MiniMax-M2.7",
         llm_api_key="test",
     )
     llm = LLMEndpoint.from_config(config)
 
     assert isinstance(llm._llm, ChatOpenAI)
-    assert llm._llm.model_name == "MiniMax-M2.5"
+    assert llm._llm.model_name == "MiniMax-M2.7"
     assert str(llm._llm.openai_api_base) == "https://api.minimax.io/v1"
     assert llm.supports_func_calling()
+
+
+@pytest.mark.base
+def test_minimax_m27_models_in_config():
+    minimax_models = LLMModelConfig._model_defaults[DefaultModelSuppliers.MINIMAX]
+    model_names = list(minimax_models.keys())
+
+    # M2.7 models should be present and come first
+    assert "MiniMax-M2.7" in model_names
+    assert "MiniMax-M2.7-highspeed" in model_names
+    assert model_names[0] == "MiniMax-M2.7"
+    assert model_names[1] == "MiniMax-M2.7-highspeed"
+
+    # Previous models still available
+    assert "MiniMax-M2.5" in model_names
+    assert "MiniMax-M2.5-highspeed" in model_names

--- a/core/tests/test_llm_endpoint.py
+++ b/core/tests/test_llm_endpoint.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from langchain_core.language_models import FakeListChatModel
 from pydantic import ValidationError
-from quivr_core.rag.entities.config import LLMEndpointConfig
+from quivr_core.rag.entities.config import DefaultModelSuppliers, LLMEndpointConfig
 from quivr_core.llm import LLMEndpoint
 
 
@@ -46,3 +46,20 @@ def test_llm_endpoint_constructor():
     )
 
     assert not llm_endpoint.supports_func_calling()
+
+
+@pytest.mark.base
+def test_llm_endpoint_minimax():
+    from langchain_openai import ChatOpenAI
+
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.MINIMAX,
+        model="MiniMax-M2.5",
+        llm_api_key="test",
+    )
+    llm = LLMEndpoint.from_config(config)
+
+    assert isinstance(llm._llm, ChatOpenAI)
+    assert llm._llm.model_name == "MiniMax-M2.5"
+    assert str(llm._llm.openai_api_base) == "https://api.minimax.io/v1"
+    assert llm.supports_func_calling()

--- a/core/tests/test_llm_endpoint.py
+++ b/core/tests/test_llm_endpoint.py
@@ -3,11 +3,7 @@ import os
 import pytest
 from langchain_core.language_models import FakeListChatModel
 from pydantic import ValidationError
-from quivr_core.rag.entities.config import (
-    DefaultModelSuppliers,
-    LLMEndpointConfig,
-    LLMModelConfig,
-)
+from quivr_core.rag.entities.config import DefaultModelSuppliers, LLMEndpointConfig
 from quivr_core.llm import LLMEndpoint
 
 
@@ -58,28 +54,12 @@ def test_llm_endpoint_minimax():
 
     config = LLMEndpointConfig(
         supplier=DefaultModelSuppliers.MINIMAX,
-        model="MiniMax-M2.7",
+        model="MiniMax-M2.5",
         llm_api_key="test",
     )
     llm = LLMEndpoint.from_config(config)
 
     assert isinstance(llm._llm, ChatOpenAI)
-    assert llm._llm.model_name == "MiniMax-M2.7"
+    assert llm._llm.model_name == "MiniMax-M2.5"
     assert str(llm._llm.openai_api_base) == "https://api.minimax.io/v1"
     assert llm.supports_func_calling()
-
-
-@pytest.mark.base
-def test_minimax_m27_models_in_config():
-    minimax_models = LLMModelConfig._model_defaults[DefaultModelSuppliers.MINIMAX]
-    model_names = list(minimax_models.keys())
-
-    # M2.7 models should be present and come first
-    assert "MiniMax-M2.7" in model_names
-    assert "MiniMax-M2.7-highspeed" in model_names
-    assert model_names[0] == "MiniMax-M2.7"
-    assert model_names[1] == "MiniMax-M2.7-highspeed"
-
-    # Previous models still available
-    assert "MiniMax-M2.5" in model_names
-    assert "MiniMax-M2.5-highspeed" in model_names


### PR DESCRIPTION
## Summary

Upgrade MiniMax provider to make `MiniMax-M3` the default model, retain `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` as alternatives, and drop the older `M2.5` / `M2.5-highspeed` entries.

## Changes

- Add `MiniMax-M3` to the MiniMax supplier model list and place it first so it is the default (512K context window, up to 128K output tokens, supports image input)
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older `MiniMax-M2.5` and `MiniMax-M2.5-highspeed`
- Update unit test to assert `MiniMax-M3` as the default model name

## Why

`MiniMax-M3` is the latest MiniMax model with a 512K context window, up to 128K max output, and image-input support. Promoting it to default gives Quivr users immediate access to the newest model, while keeping the previous-generation `M2.7` variants for users who want to opt in to the older behaviour.

## Files changed

- `core/quivr_core/rag/entities/config.py` — reorder MiniMax model list, add M3, drop M2.5 variants
- `core/tests/test_llm_endpoint.py` — update MiniMax test to use M3

## Test plan

- [x] Syntax validation passes for all modified files
- [ ] Full test suite (requires Python 3.11+)