### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/core/quivr_core/rag/entities/config.py
+++ b/core/quivr_core/rag/entities/config.py
@@ -75,6 +75,8 @@ class DefaultModelSuppliers(str, Enum):
     MISTRAL = "mistral"
     GROQ = "groq"
     GEMINI = "gemini"
+    ASTRAFLOW = "astraflow"
+    ASTRAFLOW_CN = "astraflow_cn"
 
 
 class LLMConfig(QuivrBaseConfig):
@@ -273,6 +275,39 @@ class LLMModelConfig:
                 max_context_tokens=128000,
                 max_output_tokens=4096,
                 tokenizer_hub="Quivr/gemini-tokenizer",
+            ),
+        },
+        # Astraflow (UCloud / 优刻得) — OpenAI-compatible aggregation platform
+        # supporting 200+ models.
+        # Global endpoint: https://api-us-ca.umodelverse.ai/v1 (env: ASTRAFLOW_API_KEY)
+        # China endpoint:  https://api.modelverse.cn/v1        (env: ASTRAFLOW_CN_API_KEY)
+        DefaultModelSuppliers.ASTRAFLOW: {
+            "gpt-4o": LLMConfig(
+                max_context_tokens=128000,
+                max_output_tokens=16384,
+                tokenizer_hub="Quivr/gpt-4o",
+            ),
+            "gpt-4o-mini": LLMConfig(
+                max_context_tokens=128000,
+                max_output_tokens=16384,
+                tokenizer_hub="Quivr/gpt-4o",
+            ),
+            "claude-3-5-sonnet": LLMConfig(
+                max_context_tokens=200000,
+                max_output_tokens=8192,
+                tokenizer_hub="Quivr/claude-tokenizer",
+            ),
+        },
+        DefaultModelSuppliers.ASTRAFLOW_CN: {
+            "gpt-4o": LLMConfig(
+                max_context_tokens=128000,
+                max_output_tokens=16384,
+                tokenizer_hub="Quivr/gpt-4o",
+            ),
+            "gpt-4o-mini": LLMConfig(
+                max_context_tokens=128000,
+                max_output_tokens=16384,
+                tokenizer_hub="Quivr/gpt-4o",
             ),
         },
     }


### PR DESCRIPTION
## Summary

Adds support for [Astraflow](https://www.umodelverse.ai/) (by UCloud / 优刻得), an OpenAI-compatible AI model aggregation platform supporting 200+ models.

Because Astraflow exposes an OpenAI-compatible API, integration requires only registering it as a `DefaultModelSuppliers` entry — the existing `else` branch in `LLMEndpoint.from_config` already routes unknown suppliers through `ChatOpenAI` with the configured `base_url` and `api_key`, so **no new SDK dependency is required**.

## Endpoints

| Endpoint | Base URL | Env var |
|----------|----------|---------|
| Global (US/CA) | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| China | `https://api.modelverse.cn/v1` | `ASTRAFLOW_CN_API_KEY` |

The env var names are auto-derived by the existing `normalize_to_env_variable_name` helper (`"astraflow"` → `ASTRAFLOW_API_KEY`, `"astraflow_cn"` → `ASTRAFLOW_CN_API_KEY`).

## Changes

**`core/quivr_core/rag/entities/config.py`** (single file, two locations)

1. Add `ASTRAFLOW` and `ASTRAFLOW_CN` to the `DefaultModelSuppliers` enum.
2. Add representative model configs in `LLMModelConfig._model_defaults` for both suppliers so context-window / tokenizer resolution works out of the box.

## Usage

```python
import os
from quivr_core.rag.entities.config import LLMEndpointConfig, DefaultModelSuppliers

os.environ["ASTRAFLOW_API_KEY"] = "<your-key>"

# Global (US/CA) endpoint
config = LLMEndpointConfig(
    supplier=DefaultModelSuppliers.ASTRAFLOW,
    model="gpt-4o",
    llm_base_url="https://api-us-ca.umodelverse.ai/v1",
)

# China endpoint
os.environ["ASTRAFLOW_CN_API_KEY"] = "<your-cn-key>"
config_cn = LLMEndpointConfig(
    supplier=DefaultModelSuppliers.ASTRAFLOW_CN,
    model="gpt-4o",
    llm_base_url="https://api.modelverse.cn/v1",
)
```

## Notes

- Zero new dependencies — reuses the existing `langchain_openai.ChatOpenAI` client via the `else` branch.
- Minimal surface area: one file changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Astraflow provider support (global and China) using the existing OpenAI-compatible path via `langchain_openai.ChatOpenAI`. No new dependencies.

- New Features
  - Added `ASTRAFLOW` and `ASTRAFLOW_CN` to `DefaultModelSuppliers`.
  - Added defaults in `LLMModelConfig._model_defaults` for `gpt-4o`, `gpt-4o-mini`, and `claude-3-5-sonnet`.
  - Supports `https://api-us-ca.umodelverse.ai/v1` and `https://api.modelverse.cn/v1`; env vars are `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY`.

<sup>Written for commit 399ae8a3c1ccf242b777977b88d6af3762c9abd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

