### PR TITLE
feat: add OrcaRouter support for language models

### DIFF
--- a/core/quivr_core/llm/llm_endpoint.py
+++ b/core/quivr_core/llm/llm_endpoint.py
@@ -19,6 +19,8 @@ from quivr_core.rag.utils import model_supports_function_calling
 
 logger = logging.getLogger("quivr_core")
 
+ORCAROUTER_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1"
+
 
 class LLMTokenizer:
     _cache: dict[
@@ -281,6 +283,30 @@ class LLMEndpoint:
                     max_tokens=config.max_output_tokens,
                     temperature=config.temperature,
                 )
+            elif config.supplier == DefaultModelSuppliers.ORCAROUTER:
+                # OrcaRouter is OpenAI-compatible. Default the base URL when
+                # the caller didn't override it. We do NOT mutate the config
+                # here — mutating it after hash(config) has been computed
+                # would corrupt the cache key on subsequent calls. info()
+                # reads the same default via _effective_base_url().
+                base_url = config.llm_base_url or ORCAROUTER_DEFAULT_BASE_URL
+                # Reasoning models (Claude Opus 4.7, OpenAI gpt-5*, DeepSeek
+                # reasoners) reject `temperature` upstream, so we pass None.
+                model_lower = config.model.lower()
+                is_reasoning = (
+                    model_lower.startswith("anthropic/claude-opus-4.7")
+                    or model_lower.startswith("openai/gpt-5")
+                    or "deepseek-reasoner" in model_lower
+                )
+                _llm = ChatOpenAI(
+                    model=config.model,
+                    api_key=SecretStr(config.llm_api_key)
+                    if config.llm_api_key
+                    else None,
+                    base_url=base_url,
+                    max_completion_tokens=config.max_output_tokens,
+                    temperature=None if is_reasoning else config.temperature,
+                )
             elif config.supplier == DefaultModelSuppliers.GROQ:
                 _llm = ChatGroq(
                     model=config.model,
@@ -315,12 +341,17 @@ class LLMEndpoint:
     def supports_func_calling(self) -> bool:
         return self._supports_func_calling
 
+    def _effective_base_url(self) -> str:
+        if self._config.llm_base_url:
+            return self._config.llm_base_url
+        if self._config.supplier == DefaultModelSuppliers.ORCAROUTER:
+            return ORCAROUTER_DEFAULT_BASE_URL
+        return "openai"
+
     def info(self) -> LLMInfo:
         return LLMInfo(
             model=self._config.model,
-            llm_base_url=(
-                self._config.llm_base_url if self._config.llm_base_url else "openai"
-            ),
+            llm_base_url=self._effective_base_url(),
             temperature=self._config.temperature,
             max_tokens=self._config.max_output_tokens,
             supports_function_calling=self.supports_func_calling(),

--- a/core/quivr_core/rag/entities/config.py
+++ b/core/quivr_core/rag/entities/config.py
@@ -75,6 +75,7 @@ class DefaultModelSuppliers(str, Enum):
     MISTRAL = "mistral"
     GROQ = "groq"
     GEMINI = "gemini"
+    ORCAROUTER = "orcarouter"
 
 
 class LLMConfig(QuivrBaseConfig):
@@ -273,6 +274,56 @@ class LLMModelConfig:
                 max_context_tokens=128000,
                 max_output_tokens=4096,
                 tokenizer_hub="Quivr/gemini-tokenizer",
+            ),
+        },
+        # OrcaRouter (https://www.orcarouter.ai) — OpenAI-compatible
+        # multi-vendor routing gateway. Models are exposed under
+        # "<vendor>/<model>" IDs and routed to the appropriate upstream.
+        # The synthetic "orcarouter/auto" entry maps to an admin-configurable
+        # routing policy (cheapest / balanced / quality / adaptive).
+        # See https://docs.orcarouter.ai for the full catalog and routing
+        # docs; the entries below cover the flagship models — any other
+        # model ID is accepted as a free-form string.
+        DefaultModelSuppliers.ORCAROUTER: {
+            "orcarouter/auto": LLMConfig(
+                max_context_tokens=128000,
+                max_output_tokens=16384,
+                tokenizer_hub="Quivr/gpt-4o",
+            ),
+            "openai/gpt-5": LLMConfig(
+                max_context_tokens=400000,
+                max_output_tokens=32768,
+                tokenizer_hub="Quivr/gpt-4o",
+            ),
+            "google/gemini-3.1-pro-preview": LLMConfig(
+                max_context_tokens=1048576,
+                max_output_tokens=8192,
+                tokenizer_hub="Quivr/gemini-tokenizer",
+            ),
+            "anthropic/claude-opus-4.7": LLMConfig(
+                max_context_tokens=200000,
+                max_output_tokens=8192,
+                tokenizer_hub="Quivr/claude-tokenizer",
+            ),
+            "grok/grok-4.3": LLMConfig(
+                max_context_tokens=131072,
+                max_output_tokens=8192,
+                tokenizer_hub="Quivr/gpt-4o",
+            ),
+            "deepseek/deepseek-v4-flash": LLMConfig(
+                max_context_tokens=128000,
+                max_output_tokens=8192,
+                tokenizer_hub="Quivr/gpt-4o",
+            ),
+            "minimax/minimax-m2.7-highspeed": LLMConfig(
+                max_context_tokens=200000,
+                max_output_tokens=8192,
+                tokenizer_hub="Quivr/gpt-4o",
+            ),
+            "qwen/qwen3.6-plus": LLMConfig(
+                max_context_tokens=131072,
+                max_output_tokens=8192,
+                tokenizer_hub="Quivr/gpt-4o",
             ),
         },
     }

--- a/core/tests/test_llm_endpoint.py
+++ b/core/tests/test_llm_endpoint.py
@@ -39,6 +39,105 @@ def test_llm_endpoint_from_config():
     assert llm._llm.model_name in llm.get_config().model
 
 
+@pytest.mark.base
+def test_llm_endpoint_from_config_orcarouter_auto():
+    from langchain_openai import ChatOpenAI
+    from quivr_core.rag.entities.config import DefaultModelSuppliers
+
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.ORCAROUTER,
+        model="orcarouter/auto",
+        llm_api_key="test",
+    )
+    llm = LLMEndpoint.from_config(config)
+
+    assert isinstance(llm._llm, ChatOpenAI)
+    assert llm.get_config().supplier == DefaultModelSuppliers.ORCAROUTER
+    assert llm.get_config().model == "orcarouter/auto"
+    assert str(llm._llm.openai_api_base) == "https://api.orcarouter.ai/v1"
+    assert llm._llm.temperature == config.temperature
+
+
+@pytest.mark.base
+def test_llm_endpoint_from_config_orcarouter_reasoning_drops_temperature():
+    from langchain_openai import ChatOpenAI
+    from quivr_core.rag.entities.config import DefaultModelSuppliers
+
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.ORCAROUTER,
+        model="anthropic/claude-opus-4.7",
+        llm_api_key="test",
+    )
+    llm = LLMEndpoint.from_config(config)
+
+    assert isinstance(llm._llm, ChatOpenAI)
+    assert llm._llm.temperature is None
+
+
+@pytest.mark.base
+def test_llm_endpoint_from_config_orcarouter_custom_base_url():
+    from quivr_core.rag.entities.config import DefaultModelSuppliers
+
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.ORCAROUTER,
+        model="openai/gpt-5",
+        llm_api_key="test",
+        llm_base_url="http://localhost:9999/v1",
+    )
+    llm = LLMEndpoint.from_config(config)
+
+    assert str(llm._llm.openai_api_base) == "http://localhost:9999/v1"
+
+
+@pytest.mark.base
+def test_llm_endpoint_orcarouter_info_reports_real_base_url():
+    from quivr_core.rag.entities.config import DefaultModelSuppliers
+
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.ORCAROUTER,
+        model="orcarouter/auto",
+        llm_api_key="test",
+    )
+    llm = LLMEndpoint.from_config(config)
+    info = llm.info()
+    assert info.llm_base_url == "https://api.orcarouter.ai/v1"
+
+
+@pytest.mark.base
+def test_llm_endpoint_orcarouter_env_variable_name(monkeypatch):
+    """ORCAROUTER_API_KEY should be the resolved env var (not the
+    DefaultModelSuppliers.ORCAROUTER repr)."""
+    from quivr_core.rag.entities.config import DefaultModelSuppliers
+
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "test-key-from-env")
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.ORCAROUTER,
+        model="orcarouter/auto",
+    )
+    assert config.env_variable_name == "ORCAROUTER_API_KEY"
+    assert config.llm_api_key == "test-key-from-env"
+
+
+@pytest.mark.base
+def test_llm_endpoint_orcarouter_does_not_mutate_config():
+    """from_config must not mutate the caller's config — mutation after the
+    cache hash is computed would corrupt the cache key on subsequent calls."""
+    from quivr_core.rag.entities.config import DefaultModelSuppliers
+
+    config = LLMEndpointConfig(
+        supplier=DefaultModelSuppliers.ORCAROUTER,
+        model="orcarouter/auto",
+        llm_api_key="test",
+    )
+    before_hash = hash(config)
+    assert config.llm_base_url is None
+
+    LLMEndpoint.from_config(config)
+
+    assert config.llm_base_url is None
+    assert hash(config) == before_hash
+
+
 def test_llm_endpoint_constructor():
     llm_endpoint = FakeListChatModel(responses=[])
     llm_endpoint = LLMEndpoint(


### PR DESCRIPTION
## PR Description

```markdown
# Description

This PR adds support for **OrcaRouter** (https://www.orcarouter.ai) as a new
LLM supplier in `quivr-core`. OrcaRouter is an OpenAI-compatible multi-vendor
routing gateway that exposes 150+ models from OpenAI / Anthropic / Google /
DeepSeek / xAI / MiniMax / Qwen / Kimi / etc. under a single API key, plus a
synthetic `orcarouter/auto` router that adaptively picks an upstream per
request.

Following the same pattern as the recently-merged Groq (#3633) and Gemini
(#3632) integrations, this PR:

1. Adds `ORCAROUTER = "orcarouter"` to `DefaultModelSuppliers`.
2. Registers eight flagship model entries in `LLMModelConfig._model_defaults`
   under the new supplier (auto router + one flagship per vendor). Any other
   OrcaRouter model ID is still accepted as a free-form string — the
   `LLMEndpointConfig` defaults just fall back to the generic 20k context /
   4k output budget for unrecognized models.
3. Wires up an `ORCAROUTER` branch in `LLMEndpoint.from_config` that uses
   `ChatOpenAI` against `https://api.orcarouter.ai/v1` (the SDK base URL —
   override via `LLMEndpointConfig.llm_base_url` if you point at a
   self-hosted instance). Reasoning models (`anthropic/claude-opus-4.7`,
   `openai/gpt-5*`, `deepseek-reasoner`) reject `temperature` upstream, so
   it's set to `None` for those.

### Usage

```python
from quivr_core.rag.entities.config import (
    LLMEndpointConfig,
    DefaultModelSuppliers,
)
from quivr_core.llm import LLMEndpoint

# API key from env: ORCAROUTER_API_KEY
config = LLMEndpointConfig(
    supplier=DefaultModelSuppliers.ORCAROUTER,
    model="orcarouter/auto",  # or "openai/gpt-5.5", "anthropic/claude-opus-4.7", ...
)
llm = LLMEndpoint.from_config(config)
```

### Disclosure

I'm an engineer on the OrcaRouter team. Happy to iterate on naming, model
list, or default budgets — just let me know what fits Quivr's conventions
best.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] I have ideally added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OrcaRouter as a new LLM supplier, enabling OpenAI-compatible routing to 150+ models through a single endpoint and a synthetic `orcarouter/auto` router. This adds default model configs, a default base URL, and small behavior tweaks for reasoning models.

- **New Features**
  - Added `ORCAROUTER` to `DefaultModelSuppliers`.
  - Registered eight default model configs (including `orcarouter/auto` and vendor flagships); other OrcaRouter IDs still work with generic defaults.
  - Integrated via `ChatOpenAI` targeting `https://api.orcarouter.ai/v1` by default (override with `llm_base_url`); sets `temperature=None` for reasoning models like `anthropic/claude-opus-4.7`, `openai/gpt-5*`, and `deepseek-reasoner`.
  - `info()` now reports the resolved base URL using `_effective_base_url`.
  - Supports `ORCAROUTER_API_KEY` and avoids mutating the caller’s config in `from_config`.

<sup>Written for commit dc0a6f5f0b8ca450c2f0a376f485cc105d4703ec. Summary will update on new commits. <a href="https://cubic.dev/pr/QuivrHQ/quivr/pull/3680?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

