### PR TITLE
feat: add TwelveLabs video ingestion (Pegasus) and Marengo embeddings

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
 readme = "README.md"
 requires-python = ">= 3.11"
 
+[project.optional-dependencies]
+twelvelabs = ["twelvelabs>=1.2.8"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/core/quivr_core/embeddings/twelvelabs.py
+++ b/core/quivr_core/embeddings/twelvelabs.py
@@ -1,0 +1,70 @@
+"""Marengo multimodal embeddings from TwelveLabs.
+
+This is an *opt-in* embedder. It is not registered as a default; pass an
+instance to :class:`~quivr_core.brain.brain.Brain` via the ``embedder``
+argument to use it instead of the default OpenAI embeddings.
+
+Marengo produces 512-dimensional embeddings that live in the same vector
+space for text and video, which lets a Quivr brain retrieve video segments
+(see :class:`~quivr_core.processor.implementations.twelvelabs_processor.TwelveLabsVideoProcessor`)
+from natural-language queries.
+
+Requires the ``twelvelabs`` extra::
+
+    pip install quivr-core[twelvelabs]
+
+and a ``TWELVELABS_API_KEY`` (grab a free one at https://twelvelabs.io).
+"""
+
+import os
+from typing import List
+
+from langchain_core.embeddings import Embeddings
+
+
+class TwelveLabsEmbeddings(Embeddings):
+    """LangChain ``Embeddings`` backed by the TwelveLabs Marengo model.
+
+    Args:
+        api_key: TwelveLabs API key. Defaults to the ``TWELVELABS_API_KEY``
+            environment variable.
+        model_name: Marengo model to use. Defaults to ``"marengo3.0"``.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model_name: str = "marengo3.0",
+    ) -> None:
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError as e:
+            raise ImportError(
+                "Please install quivr-core[twelvelabs] to use TwelveLabsEmbeddings."
+            ) from e
+
+        api_key = api_key or os.getenv("TWELVELABS_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "A TwelveLabs API key is required. Pass `api_key` or set the "
+                "TWELVELABS_API_KEY environment variable."
+            )
+
+        self.model_name = model_name
+        self._client = TwelveLabs(api_key=api_key)
+
+    def _embed_text(self, text: str) -> List[float]:
+        resp = self._client.embed.create(model_name=self.model_name, text=text)
+        text_embedding = resp.text_embedding
+        if text_embedding is None or not text_embedding.segments:
+            raise RuntimeError(
+                f"TwelveLabs returned no embedding for text "
+                f"(error: {getattr(text_embedding, 'error_message', None)})"
+            )
+        return list(text_embedding.segments[0].float_)
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [self._embed_text(text) for text in texts]
+
+    def embed_query(self, text: str) -> List[float]:
+        return self._embed_text(text)

--- a/core/quivr_core/processor/implementations/twelvelabs_processor.py
+++ b/core/quivr_core/processor/implementations/twelvelabs_processor.py
@@ -1,0 +1,158 @@
+"""Video ingestion through TwelveLabs Pegasus.
+
+This is an *opt-in* processor: it is not registered by default. Register it
+explicitly to ingest video files into a Quivr brain::
+
+    from quivr_core.processor.registry import register_processor
+    from quivr_core.processor.implementations.twelvelabs_processor import (
+        TwelveLabsVideoProcessor,
+    )
+
+    register_processor(".mp4", TwelveLabsVideoProcessor, override=True)
+
+Pegasus watches the whole video (visuals, audio, on-screen text) and returns a
+natural-language description, which is then chunked into searchable documents.
+
+Requires the ``twelvelabs`` extra::
+
+    pip install quivr-core[twelvelabs]
+
+and a ``TWELVELABS_API_KEY`` (grab a free one at https://twelvelabs.io).
+"""
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+from langchain_core.documents import Document
+
+from quivr_core.files.file import FileExtension, QuivrFile
+from quivr_core.processor.implementations.simple_txt_processor import (
+    recursive_character_splitter,
+)
+from quivr_core.processor.processor_base import ProcessedDocument, ProcessorBase
+from quivr_core.processor.splitter import SplitterConfig
+
+logger = logging.getLogger("quivr_core")
+
+_DEFAULT_PROMPT = (
+    "Describe this video in detail. Include the topics covered, what is shown "
+    "on screen, what is said, and any text that appears, so the description can "
+    "be used to answer questions about the video."
+)
+
+
+class TwelveLabsVideoProcessor(ProcessorBase):
+    """Ingest video files by analyzing them with the TwelveLabs Pegasus model.
+
+    Args:
+        api_key: TwelveLabs API key. Defaults to ``TWELVELABS_API_KEY`` env var.
+        model_name: Pegasus model to use. Defaults to ``"pegasus1.5"``.
+        prompt: Analysis prompt sent to Pegasus.
+        max_tokens: Maximum tokens for the generated description.
+        splitter_config: How to chunk the generated description.
+        poll_interval: Seconds between asset-status polls.
+        timeout: Max seconds to wait for the uploaded asset to be ready.
+    """
+
+    supported_extensions = [
+        FileExtension.mp4,
+        FileExtension.webm,
+        FileExtension.mpeg,
+    ]
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model_name: str = "pegasus1.5",
+        prompt: str = _DEFAULT_PROMPT,
+        max_tokens: int = 2048,
+        splitter_config: SplitterConfig = SplitterConfig(),
+        poll_interval: float = 5.0,
+        timeout: float = 600.0,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError as e:
+            raise ImportError(
+                "Please install quivr-core[twelvelabs] to use TwelveLabsVideoProcessor."
+            ) from e
+
+        api_key = api_key or os.getenv("TWELVELABS_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "A TwelveLabs API key is required. Pass `api_key` or set the "
+                "TWELVELABS_API_KEY environment variable."
+            )
+
+        self.model_name = model_name
+        self.prompt = prompt
+        self.max_tokens = max_tokens
+        self.splitter_config = splitter_config
+        self.poll_interval = poll_interval
+        self.timeout = timeout
+        self._client = TwelveLabs(api_key=api_key)
+
+    @property
+    def processor_metadata(self) -> dict[str, Any]:
+        return {
+            "processor_cls": "TwelveLabsVideoProcessor",
+            "model_name": self.model_name,
+            "splitter": self.splitter_config.model_dump(),
+        }
+
+    def _analyze(self, path: str) -> str:
+        """Upload the video as an asset, wait for it, then run Pegasus.
+
+        Runs in a worker thread (the TwelveLabs SDK is synchronous).
+        """
+        from twelvelabs.types.video_context import VideoContext_AssetId
+
+        with open(path, "rb") as f:
+            asset = self._client.assets.create(method="direct", file=f)
+
+        waited = 0.0
+        while asset.status != "ready":
+            if asset.status == "failed":
+                raise RuntimeError(f"TwelveLabs asset {asset.id} failed to process")
+            if waited >= self.timeout:
+                raise TimeoutError(
+                    f"TwelveLabs asset {asset.id} not ready after {self.timeout}s "
+                    f"(status: {asset.status})"
+                )
+            import time
+
+            time.sleep(self.poll_interval)
+            waited += self.poll_interval
+            asset = self._client.assets.retrieve(asset.id)
+
+        result = self._client.analyze(
+            model_name=self.model_name,
+            video=VideoContext_AssetId(type="asset_id", asset_id=asset.id),
+            prompt=self.prompt,
+            max_tokens=self.max_tokens,
+        )
+        if not result.data:
+            raise RuntimeError(
+                f"TwelveLabs analysis returned no data (error: {result.error})"
+            )
+        return result.data
+
+    async def process_file_inner(self, file: QuivrFile) -> ProcessedDocument[str]:
+        content = await asyncio.to_thread(self._analyze, str(file.path))
+
+        doc = Document(page_content=content)
+        docs = recursive_character_splitter(
+            doc,
+            self.splitter_config.chunk_size,
+            self.splitter_config.chunk_overlap,
+        )
+
+        return ProcessedDocument(
+            chunks=docs,
+            processor_cls="TwelveLabsVideoProcessor",
+            processor_response=content,
+        )

--- a/core/quivr_core/processor/registry.py
+++ b/core/quivr_core/processor/registry.py
@@ -119,6 +119,16 @@ def defaults_to_proc_entries(
                 priority=None,
             )
 
+    # Opt-in video ingestion via TwelveLabs Pegasus. Only loads when the
+    # `twelvelabs` extra is installed; otherwise it is skipped at resolution time.
+    _append_proc_mapping(
+        mapping=base_processors,
+        file_exts=[FileExtension.mp4, FileExtension.webm, FileExtension.mpeg],
+        cls_mod="quivr_core.processor.implementations.twelvelabs_processor.TwelveLabsVideoProcessor",
+        errtxt="can't import TwelveLabsVideoProcessor. Please install quivr-core[twelvelabs] to ingest videos with TwelveLabs Pegasus",
+        priority=None,
+    )
+
     # TODO(@aminediro): Megaparse should register itself
     # Append Megaparse
     _append_proc_mapping(

--- a/core/tests/test_twelvelabs.py
+++ b/core/tests/test_twelvelabs.py
@@ -1,0 +1,40 @@
+import os
+
+import pytest
+from quivr_core.files.file import FileExtension
+from quivr_core.processor.registry import known_processors
+
+
+def test_twelvelabs_processor_registered():
+    """The Pegasus video processor is registered for video extensions."""
+    for ext in [FileExtension.mp4, FileExtension.webm, FileExtension.mpeg]:
+        assert ext in known_processors
+        assert any(
+            "TwelveLabsVideoProcessor" in entry.cls_mod
+            for entry in known_processors[ext]
+        )
+
+
+def test_twelvelabs_embeddings_requires_key(monkeypatch):
+    """Without a key (and without an explicit one), construction raises."""
+    twelvelabs = pytest.importorskip("twelvelabs")  # noqa: F841
+    from quivr_core.embeddings.twelvelabs import TwelveLabsEmbeddings
+
+    monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        TwelveLabsEmbeddings()
+
+
+@pytest.mark.skipif(
+    not os.getenv("TWELVELABS_API_KEY"),
+    reason="TWELVELABS_API_KEY not set",
+)
+def test_twelvelabs_embeddings_dim():
+    """Marengo returns a 512-dimensional embedding for a text query."""
+    pytest.importorskip("twelvelabs")
+    from quivr_core.embeddings.twelvelabs import TwelveLabsEmbeddings
+
+    embedder = TwelveLabsEmbeddings()
+    vec = embedder.embed_query("a red car driving on a highway")
+    assert len(vec) == 512
+    assert all(isinstance(x, float) for x in vec[:8])

--- a/docs/docs/parsers/twelvelabs.md
+++ b/docs/docs/parsers/twelvelabs.md
@@ -1,0 +1,55 @@
+# TwelveLabs (video + multimodal embeddings)
+
+[TwelveLabs](https://twelvelabs.io) provides video-native foundation models.
+Two opt-in integrations are available in `quivr-core`:
+
+- **Pegasus** — `TwelveLabsVideoProcessor` ingests video files (`.mp4`,
+  `.webm`, `.mpeg`) by generating a natural-language description of the whole
+  video (visuals, speech, on-screen text), which is then chunked into
+  searchable documents.
+- **Marengo** — `TwelveLabsEmbeddings` is a LangChain `Embeddings`
+  implementation that produces 512-dimensional multimodal embeddings.
+
+Both require the `twelvelabs` extra and a `TWELVELABS_API_KEY` (there's a
+generous free tier at [twelvelabs.io](https://twelvelabs.io)):
+
+```bash
+pip install "quivr-core[twelvelabs]"
+export TWELVELABS_API_KEY=...
+```
+
+## Ingesting videos with Pegasus
+
+The video processor is registered for video extensions but only loads when the
+`twelvelabs` extra is installed, so the default behavior of the library is
+unchanged. To use it explicitly:
+
+```python
+from quivr_core.processor.registry import register_processor
+from quivr_core.processor.implementations.twelvelabs_processor import (
+    TwelveLabsVideoProcessor,
+)
+
+register_processor(".mp4", TwelveLabsVideoProcessor, override=True)
+```
+
+## Marengo embeddings
+
+```python
+from quivr_core import Brain
+from quivr_core.embeddings.twelvelabs import TwelveLabsEmbeddings
+
+brain = Brain.from_files(
+    name="my videos",
+    file_paths=["intro.mp4"],
+    embedder=TwelveLabsEmbeddings(),
+)
+```
+
+::: quivr_core.processor.implementations.twelvelabs_processor
+    options:
+      heading_level: 2
+
+::: quivr_core.embeddings.twelvelabs
+    options:
+      heading_level: 2

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
           - parsers/index.md
           - parsers/megaparse.md
           - parsers/simple.md
+          - parsers/twelvelabs.md
       - Vector Stores:
           - vectorstores/index.md
           - vectorstores/faiss.md


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

# Description

This PR adds two **opt-in** [TwelveLabs](https://twelvelabs.io) integrations to `quivr-core` so brains can understand and search video content:

- **`TwelveLabsVideoProcessor` (Pegasus)** — a processor for `.mp4` / `.webm` / `.mpeg` files. It uploads the video to TwelveLabs, runs the Pegasus video-understanding model to produce a natural-language description (visuals, speech, and on-screen text), and chunks that description into searchable `Document`s. It's registered for the existing video file extensions, but only loads when the optional `twelvelabs` extra is installed — so the library's default behavior is unchanged.
- **`TwelveLabsEmbeddings` (Marengo)** — a LangChain `Embeddings` implementation backed by the Marengo model (512-dim multimodal embeddings). It can be passed to `Brain` via the existing `embedder` argument.

## Why this helps Quivr

Quivr already declares video extensions (`.mp4`, `.webm`, `.mpeg`) in `FileExtension`, but ships no processor for them. This makes video a first-class, ingestible source: Pegasus turns a video into rich text Quivr can RAG over, and Marengo gives a video-native embedding space for retrieval.

## Opt-in / non-breaking

- Nothing is enabled by default. The default embedder (OpenAI) and all existing processors are untouched.
- The video processor is lazy-loaded; without `quivr-core[twelvelabs]` installed it's simply skipped at resolution time (same pattern the repo already uses for optional processors).
- New dependency lives behind a `[twelvelabs]` optional-dependency group.

## How it was tested

- `tests/test_twelvelabs.py` (run on Python 3.12):
  - `test_twelvelabs_processor_registered` — confirms the Pegasus processor is registered for `.mp4`/`.webm`/`.mpeg`.
  - `test_twelvelabs_embeddings_requires_key` — no-network unit test (skips if SDK absent).
  - `test_twelvelabs_embeddings_dim` — live test (gated on `TWELVELABS_API_KEY`, skipped without it) asserting Marengo returns a **512-dim** vector. Verified passing against the live API.
- Pegasus processor wiring verified (instantiation, supported extensions, metadata, asset+analyze call path); a full end-to-end video analysis is server-side and slow, so that path is wiring-verified with the full run pending.
- `ruff check` and `ruff format --check` pass on all changed files (repo-pinned ruff 0.6.1). Existing processor/registry tests still collect unchanged.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] I have ideally added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opt-in TwelveLabs support to index and search video: Pegasus for video understanding and Marengo for 512‑dim embeddings. Defaults stay the same; features load only when the `twelvelabs` extra is installed.

- New Features
  - `TwelveLabsVideoProcessor` (Pegasus): ingests `.mp4`, `.webm`, `.mpeg`, generates a detailed natural‑language description, then chunks it for search. Registered for video extensions and lazy‑loaded.
  - `TwelveLabsEmbeddings` (Marengo): LangChain embeddings (`marengo3.0`) with 512‑dim vectors; pass to `Brain` via the `embedder` argument.
  - Added docs and tests for registration and embedding behavior.

- Dependencies
  - Adds optional extra `[twelvelabs]` with `twelvelabs>=1.2.8`.
  - Requires `TWELVELABS_API_KEY` to use either integration.

<sup>Written for commit c8816915200adc83d0eb157207a3213d789a8ea5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QuivrHQ/quivr/pull/3690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

