### PR TITLE
fix(security): default allow_dangerous_deserialization to False in Brain.load()

### DIFF
--- a/core/quivr_core/brain/brain.py
+++ b/core/quivr_core/brain/brain.py
@@ -145,11 +145,15 @@ class Brain:
         console.print(panel)
 
     @classmethod
-    def load(cls, folder_path: str | Path) -> Self:
+    def load(cls, folder_path: str | Path, allow_dangerous_deserialization: bool = False) -> Self:
         """
         Load a brain from a folder path.
         Args:
             folder_path (str | Path): The path to the folder containing the brain.
+            allow_dangerous_deserialization (bool): Set to True to load FAISS indexes
+                that use pickle serialization. This is dangerous and can lead to
+                arbitrary code execution if the index file is untrusted. Only enable
+                for brains you created yourself or fully trust. Defaults to False.
         Returns:
             Brain: The brain loaded from the folder path.
         Example:
@@ -191,7 +195,7 @@ class Brain:
             vector_db = FAISS.load_local(
                 folder_path=bserialized.vectordb_config.vectordb_folder_path,
                 embeddings=embedder,
-                allow_dangerous_deserialization=True,
+                allow_dangerous_deserialization=allow_dangerous_deserialization,
             )
         else:
             raise ValueError("Unsupported vectordb")


### PR DESCRIPTION
## Summary

- Changed `allow_dangerous_deserialization` from hardcoded `True` to a parameter defaulting to `False`
- Users who need to load pickle-based FAISS indexes must now explicitly pass `allow_dangerous_deserialization=True`

## Security Impact

`Brain.load()` unconditionally called `FAISS.load_local()` with `allow_dangerous_deserialization=True`, enabling arbitrary code execution via crafted `index.pkl` files. Attack vector: shared brain directories via HuggingFace Hub, GitHub, or email.

A crafted pickle file in `index.pkl` gives RCE when any victim calls `Brain.load(path)`.

Fixes #3691

## Breaking Change

Existing users calling `Brain.load(path)` without the parameter will get a `ValueError` from FAISS if their index uses pickle serialization. They should pass `allow_dangerous_deserialization=True` if they trust the brain source:

```python
# Safe default (recommended)
brain = Brain.load("path/to/brain")

# Explicit opt-in for trusted brains only
brain = Brain.load("path/to/brain", allow_dangerous_deserialization=True)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `allow_dangerous_deserialization` to False in `Brain.load()` and require explicit opt-in. This blocks remote code execution from untrusted pickle-based `FAISS` indexes.

- **Bug Fixes**
  - Replaced hardcoded `True` with a parameter passed to `FAISS.load_local`, defaulting to `False`.
  - Prevents RCE via crafted `index.pkl` when loading shared brains.

- **Migration**
  - If your index uses pickle serialization and you trust the source, call `Brain.load(path, allow_dangerous_deserialization=True)`. Otherwise, `FAISS` may raise a `ValueError`.

<sup>Written for commit 52f257eb98200245536ab5bc2975f6a9ede3fe73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QuivrHQ/quivr/pull/3692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

