### PR TITLE
fix: remove unsafe allow_dangerous_deserialization in Brain.load

### DIFF
--- a/core/quivr_core/brain/brain.py
+++ b/core/quivr_core/brain/brain.py
@@ -191,7 +191,7 @@ class Brain:
             vector_db = FAISS.load_local(
                 folder_path=bserialized.vectordb_config.vectordb_folder_path,
                 embeddings=embedder,
-                allow_dangerous_deserialization=True,
+              
             )
         else:
             raise ValueError("Unsupported vectordb")

--- a/test_brain_deserialization.py
+++ b/test_brain_deserialization.py
@@ -1,0 +1,19 @@
+import pytest
+import pickle
+from pathlib import Path
+from core.quivr_core.brain.brain import Brain
+
+class DummyObject:
+    def __reduce__(self):
+        # harmless payload that would normally execute code
+        return (print, ("UNSAFE DESERIALIZATION TRIGGERED",))
+
+def test_brain_load_blocks_unsafe_deserialization(tmp_path: Path):
+    # Create a fake pickle file with DummyObject
+    payload_path = tmp_path / "vectordb.pkl"
+    with open(payload_path, "wb") as f:
+        pickle.dump(DummyObject(), f)
+
+    # Try to load using Brain.load
+    with pytest.raises(Exception):
+        Brain.load(folder_path=tmp_path)


### PR DESCRIPTION
### Summary
Removed unsafe `allow_dangerous_deserialization=True` flag in Brain.load.

### Details
The Brain class used FAISS.load_local with `allow_dangerous_deserialization=True`. This allowed arbitrary code execution when loading crafted pickle files (e.g., malicious `index.pkl`).

### Location
File: core/quivr_core/brain/brain.py, line 194

### Current Behavior
vector_db = FAISS.load_local(..., allow_dangerous_deserialization=True)

### Expected Behavior
vector_db = FAISS.load_local(...)

### Verification
Created a malicious pickle file and confirmed arbitrary command execution when loaded. After fix, unsafe deserialization is no longer possible.

### Suggested Fix
Removed `allow_dangerous_deserialization=True` and rely on FAISS’s safe native format.
):

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsafe `allow_dangerous_deserialization=True` in `Brain.load` when calling `FAISS.load_local`. This prevents arbitrary code execution from crafted pickle files, relies on FAISS’s safe defaults, and includes a regression test to ensure unsafe deserialization is blocked.

<sup>Written for commit 05f2693188ddb1c5d283da809b38e7712304ae93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QuivrHQ/quivr/pull/3696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

